### PR TITLE
Gemini/open router version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "Python 3",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "README.md",
+        "app/web/web_app.py"
+      ]
+    },
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ]
+    }
+  },
+  "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; pip3 install --user streamlit; echo '✅ Packages installed and Requirements met'",
+  "postAttachCommand": {
+    "server": "streamlit run app/web/web_app.py --server.enableCORS false --server.enableXsrfProtection false"
+  },
+  "portsAttributes": {
+    "8501": {
+      "label": "Application",
+      "onAutoForward": "openPreview"
+    }
+  },
+  "forwardPorts": [
+    8501
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,21 +1,35 @@
-# Hallucination Risk Calculator & Prompt Re-engineering Toolkit (Gemini-only)
+# Hallucination Risk Calculator & Prompt Re-engineering Toolkit (Multi-Provider)
 
 **Post-hoc calibration without retraining** for large language models. This toolkit turns a raw prompt into:
-1) a **bounded hallucination risk** using the Expectation-level Decompression Law (EDFL), and  
+1) a **bounded hallucination risk** using the Expectation-level Decompression Law (EDFL), and
 2) a **decision** to **ANSWER** or **REFUSE** under a target SLA, with transparent math (nats).
+
+**Full Multi-Provider Support** with seamless switching between:
+- **Google Gemini** (2.0/2.5 series + legacy models via official API)
+- **Any OpenRouter Model** (Claude, GPT, Gemini, Llama, and 100+ others via OpenAI-compatible API)
 
 It supports two deployment modes:
 
 - **Evidence-based:** prompts include *evidence/context*; rolling priors are built by erasing that evidence.
 - **Closed-book:** prompts have *no evidence*; rolling priors are built by semantic masking of entities/numbers/titles.
 
-All scoring relies **only** on the Google Gemini API with support for:
+All scoring relies **only** on the selected provider's API with comprehensive model support:
+
+**Google Gemini via Official API:**
 - `gemini-2.5-pro` (Most capable)
 - `gemini-2.5-flash` (Fast & capable)
 - `gemini-2.5-flash-lite` (Fast & lightweight)
 - `gemini-2.0-flash` (Previous generation)
 - `gemini-2.0-flash-lite` (Lightweight version)
 - `gemini-1.5-pro` & `gemini-1.5-flash` (Legacy models)
+
+**Any OpenRouter Model (100+ available):**
+- `anthropic/claude-3.5-sonnet`, `anthropic/claude-3-opus`, `anthropic/claude-3-haiku`
+- `openai/gpt-4o`, `openai/gpt-4o-mini`, `openai/gpt-4-turbo`
+- `google/gemini-flash-1.5-8b`, `google/gemini-pro`
+- `meta/llama-3.1-405b-instruct`, `meta/llama-3.1-70b-instruct`
+- `mistral/mistral-large`, `mistral/codestral-mamba`
+- And [140+ more models](https://openrouter.ai/docs/models) across providers
 
 No retraining required.
 
@@ -36,12 +50,25 @@ No retraining required.
 
 ## Install & Setup
 
+**Install dependencies:**
 ```bash
-pip install --upgrade google-generativeai>=0.5.0
+pip install --upgrade google-generativeai>=0.5.0 openai requests
+```
+
+**Get API Keys:**
+
+**For Google Gemini:**
+```bash
 export GOOGLE_API_KEY=AIza...  # Get from Google AI Studio
 ```
 
-> The module uses `google-generativeai>=0.5.0` and the Gemini API with support for Gemini 1.5 and 2.0/2.5 models.
+**For OpenRouter (optional, access to 100+ models):**
+```bash
+export OPENROUTER_API_KEY=sk-or-v1-...  # Get from https://openrouter.ai/edit-keys
+# Supports Claude, GPT, Llama, Mistral, and many others with single API
+```
+
+> **Supported Models:** The toolkit works with Google Gemini models via their official API and any OpenRouter model via their OpenAI-compatible endpoint. No modifications needed - just change the provider selection.
 
 ---
 
@@ -208,9 +235,11 @@ for m in metrics:
 
 ### Core Classes
 
-- `GeminiBackend(model, api_key=None)` – wraps Gemini API
-- `GeminiItem(prompt, n_samples=5, m=6, skeleton_policy="auto")` – one evaluation item
-- `GeminiPlanner(backend, temperature=0.5)` – runs evaluation:
+**Multi-Provider Backend Classes:**
+- `GeminiBackend(model, api_key=None)` – Google Gemini via official API (2.0/2.5 series + legacy)
+- `OpenRouterBackend(model, api_key=None)` – Any OpenRouter model (100+ models, OpenAI-compatible)
+- `GeminiItem(prompt, n_samples=5, m=6, skeleton_policy="auto")` – evaluation item (works with all backends)
+- `GeminiPlanner(backend, temperature=0.5)` – unified evaluation runner:
   - `run(items, h_star, isr_threshold, margin_extra_bits, B_clip=12.0, clip_mode="one-sided") -> List[ItemMetrics]`
   - `aggregate(items, metrics, alpha=0.05, h_star, ...) -> AggregateReport`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Hallucination Risk Calculator & Prompt Re-engineering Toolkit (OpenAI-only)
+# Hallucination Risk Calculator & Prompt Re-engineering Toolkit (Gemini-only)
 
-**Post-hoc calibration without retraining** for large language models. This toolkit turns a raw prompt into:  
+**Post-hoc calibration without retraining** for large language models. This toolkit turns a raw prompt into:
 1) a **bounded hallucination risk** using the Expectation-level Decompression Law (EDFL), and  
 2) a **decision** to **ANSWER** or **REFUSE** under a target SLA, with transparent math (nats).
 
@@ -9,7 +9,15 @@ It supports two deployment modes:
 - **Evidence-based:** prompts include *evidence/context*; rolling priors are built by erasing that evidence.
 - **Closed-book:** prompts have *no evidence*; rolling priors are built by semantic masking of entities/numbers/titles.
 
-All scoring relies **only** on the OpenAI Chat Completions API. No retraining required.
+All scoring relies **only** on the Google Gemini API with support for:
+- `gemini-2.5-pro` (Most capable)
+- `gemini-2.5-flash` (Fast & capable)
+- `gemini-2.5-flash-lite` (Fast & lightweight)
+- `gemini-2.0-flash` (Previous generation)
+- `gemini-2.0-flash-lite` (Lightweight version)
+- `gemini-1.5-pro` & `gemini-1.5-flash` (Legacy models)
+
+No retraining required.
 
 ---
 
@@ -29,11 +37,11 @@ All scoring relies **only** on the OpenAI Chat Completions API. No retraining re
 ## Install & Setup
 
 ```bash
-pip install --upgrade openai
-export OPENAI_API_KEY=sk-...
+pip install --upgrade google-generativeai>=0.5.0
+export GOOGLE_API_KEY=AIza...  # Get from Google AI Studio
 ```
 
-> The module uses `openai>=1.0.0` and the Chat Completions API (e.g., `gpt-4o`, `gpt-4o-mini`).
+> The module uses `google-generativeai>=0.5.0` and the Gemini API with support for Gemini 1.5 and 2.0/2.5 models.
 
 ---
 
@@ -200,9 +208,9 @@ for m in metrics:
 
 ### Core Classes
 
-- `OpenAIBackend(model, api_key=None)` – wraps Chat Completions API
-- `OpenAIItem(prompt, n_samples=5, m=6, fields_to_erase=None, skeleton_policy="auto")` – one evaluation item
-- `OpenAIPlanner(backend, temperature=0.5, q_floor=None)` – runs evaluation:
+- `GeminiBackend(model, api_key=None)` – wraps Gemini API
+- `GeminiItem(prompt, n_samples=5, m=6, skeleton_policy="auto")` – one evaluation item
+- `GeminiPlanner(backend, temperature=0.5)` – runs evaluation:
   - `run(items, h_star, isr_threshold, margin_extra_bits, B_clip=12.0, clip_mode="one-sided") -> List[ItemMetrics]`
   - `aggregate(items, metrics, alpha=0.05, h_star, ...) -> AggregateReport`
 

--- a/app/cli/frontend.py
+++ b/app/cli/frontend.py
@@ -3,7 +3,7 @@ CLI Front-End: Hallucination Risk Checker
 ----------------------------------------
 
 Interactive CLI:
-- Enter/OpenAI API key (or use `OPENAI_API_KEY`).
+- Enter/OpenAI API key (fresh entry required, no caching).
 - Pick a model (default: `gpt-4o-mini`).
 - Type your prompt.
 - Run a closed-book risk check and see a clear report with next steps.
@@ -63,10 +63,7 @@ def select_model_interactive(default: str = DEFAULT_MODELS[0]) -> str:
 
 
 def get_api_key_interactive() -> str:
-    key = os.environ.get("OPENAI_API_KEY", "").strip()
-    if key:
-        return key
-    key = getpass("Enter OPENAI_API_KEY: ").strip()
+    key = getpass("Enter OpenAI API key: ").strip()
     return key
 
 
@@ -160,13 +157,10 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
 def main(argv: Optional[list[str]] = None) -> int:
     args = parse_args(argv)
 
-    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    api_key = get_api_key_interactive()
     if not api_key:
-        print("No OPENAI_API_KEY found in environment.")
-        api_key = get_api_key_interactive()
-        if not api_key:
-            print("No API key provided; aborting.")
-            return 1
+        print("No API key provided; aborting.")
+        return 1
 
     model = args.model or select_model_interactive()
     if not model:

--- a/app/examples/example.py
+++ b/app/examples/example.py
@@ -7,21 +7,21 @@ evidence, reporting Δ̄, B2T, ISR, and an EDFL RoH bound.
 """
 
 from scripts.hallucination_toolkit import (
-    OpenAIBackend,
-    OpenAIItem,
-    OpenAIPlanner,
+    GeminiBackend,
+    GeminiItem,
+    GeminiPlanner,
     generate_answer_if_allowed,
 )
 
 
 def main() -> None:
-    backend = OpenAIBackend(model="gpt-4o-mini")
+    backend = GeminiBackend(model="gemini-1.5-flash")
     prompt = (
         "If James has five apples and eats three of them, "
         "how many apples does he have left?"
     )
-    item = OpenAIItem(prompt=prompt, n_samples=7, m=6, skeleton_policy="closed_book")
-    planner = OpenAIPlanner(backend, temperature=0.3)
+    item = GeminiItem(prompt=prompt, n_samples=7, m=6, skeleton_policy="closed_book")
+    planner = GeminiPlanner(backend, temperature=0.3)
     metrics = planner.run([item], h_star=0.05, isr_threshold=1.0, margin_extra_bits=0.0, B_clip=12.0, clip_mode="one-sided")
     for m in metrics:
         print(f"Answer? {m.decision_answer} | {m.rationale}")

--- a/app/examples/example.py
+++ b/app/examples/example.py
@@ -15,7 +15,9 @@ from scripts.hallucination_toolkit import (
 
 
 def main() -> None:
-    backend = GeminiBackend(model="gemini-1.5-flash")
+    # Using latest Gemini 2.5 model - update this to try different models
+    model_name = "gemini-2.5-flash"  # Options: gemini-2.5-pro, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.0-flash, gemini-2.0-flash-lite, gemini-1.5-pro, gemini-1.5-flash
+    backend = GeminiBackend(model=model_name)
     prompt = (
         "If James has five apples and eats three of them, "
         "how many apples does he have left?"

--- a/app/web/web_app.py
+++ b/app/web/web_app.py
@@ -18,9 +18,16 @@ from __future__ import annotations
 
 import json
 import os
+import sys
+from pathlib import Path
 from dataclasses import asdict
 
 import streamlit as st
+
+# Add the parent directory to the path to ensure imports work in Streamlit Cloud
+current_dir = Path(__file__).parent
+project_root = current_dir.parent
+sys.path.insert(0, str(project_root))
 
 from scripts.hallucination_toolkit import (
     GeminiBackend,

--- a/app/web/web_app.py
+++ b/app/web/web_app.py
@@ -24,13 +24,56 @@ from dataclasses import asdict
 
 import streamlit as st
 
-# Add the parent directory to the path to ensure imports work correctly
-current_dir = Path(__file__).parent  # /workspaces/hallucination_bayes/app/web
-project_root = current_dir.parent   # /workspaces/hallucination_bayes
-sys.path.insert(0, str(project_root))
+# Robust import path resolution for both local and cloud deployment
+try:
+    # Try standard relative import first (works in local env)
+    import scripts.hallucination_toolkit as in_sys
+    GeminiBackend = in_sys.GeminiBackend
+    OpenRouterBackend = in_sys.OpenRouterBackend
+    GeminiItem = in_sys.GeminiItem
+    GeminiPlanner = in_sys.GeminiPlanner
+    generate_answer_if_allowed = in_sys.generate_answer_if_allowed
+    make_sla_certificate = in_sys.make_sla_certificate
+except ImportError:
+    # Fallback to dynamic path resolution (for cloud deployment)
+    current_dir = Path(__file__).parent
+    project_root = current_dir.parent
 
-# Also add the scripts directory directly
-sys.path.insert(0, str(project_root / "scripts"))
+    # Try multiple potential paths
+    possible_paths = [
+        project_root,
+        project_root / "scripts",
+        current_dir / ".." / "scripts",
+        current_dir / "../../../scripts",
+        project_root.parent / "hallucination_bayes" / "scripts",
+    ]
+
+    for path_obj in possible_paths:
+        path_str = str(path_obj)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+    try:
+        from scripts.hallucination_toolkit import (
+            GeminiBackend,
+            OpenRouterBackend,
+            GeminiItem,
+            GeminiPlanner,
+            generate_answer_if_allowed,
+            make_sla_certificate,
+        )
+    except ImportError:
+        # Absolute fallback - this should work locally at least
+        import sys
+        sys.path.append('scripts')
+        from hallucination_toolkit import (
+            GeminiBackend,
+            OpenRouterBackend,
+            GeminiItem,
+            GeminiPlanner,
+            generate_answer_if_allowed,
+            make_sla_certificate,
+        )
 
 from scripts.hallucination_toolkit import (
     GeminiBackend,

--- a/app/web/web_app.py
+++ b/app/web/web_app.py
@@ -75,16 +75,6 @@ except ImportError:
             make_sla_certificate,
         )
 
-from scripts.hallucination_toolkit import (
-    GeminiBackend,
-    OpenRouterBackend,
-    GeminiItem,
-    GeminiPlanner,
-    generate_answer_if_allowed,
-    make_sla_certificate,
-)
-
-
 DEFAULT_MODELS = [
     "gemini-2.5-pro",
     "gemini-2.5-flash",

--- a/app/web/web_app.py
+++ b/app/web/web_app.py
@@ -32,8 +32,13 @@ from scripts.hallucination_toolkit import (
 
 
 DEFAULT_MODELS = [
-    "gemini-1.5-flash",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
     "gemini-1.5-pro",
+    "gemini-1.5-flash",
 ]
 
 

--- a/app/web/web_app.py
+++ b/app/web/web_app.py
@@ -24,10 +24,13 @@ from dataclasses import asdict
 
 import streamlit as st
 
-# Add the parent directory to the path to ensure imports work in Streamlit Cloud
-current_dir = Path(__file__).parent
-project_root = current_dir.parent
+# Add the parent directory to the path to ensure imports work correctly
+current_dir = Path(__file__).parent  # /workspaces/hallucination_bayes/app/web
+project_root = current_dir.parent   # /workspaces/hallucination_bayes
 sys.path.insert(0, str(project_root))
+
+# Also add the scripts directory directly
+sys.path.insert(0, str(project_root / "scripts"))
 
 from scripts.hallucination_toolkit import (
     GeminiBackend,

--- a/app/web/web_app.py
+++ b/app/web/web_app.py
@@ -212,7 +212,7 @@ def main() -> None:
     run_clicked = col_run.button("Run evaluation", type="primary")
     reset_clicked = col_reset.button("Reset")
     if reset_clicked:
-        st.experimental_rerun()
+        st.rerun()
 
     if run_clicked:
         if not prompt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 openai>=1.0.0
 streamlit>=1.28.0
-
+google-generativeai>=0.5.0


### PR DESCRIPTION
Full Multi-Provider Support with seamless switching between:

Google Gemini (2.0/2.5 series + legacy models via official API)
Any OpenRouter Model (Claude, GPT, Gemini, Llama, and 100+ others via OpenAI-compatible API)

Google Gemini via Official API:

gemini-2.5-pro (Most capable)
gemini-2.5-flash (Fast & capable)
gemini-2.5-flash-lite (Fast & lightweight)
gemini-2.0-flash (Previous generation)
gemini-2.0-flash-lite (Lightweight version)
gemini-1.5-pro & gemini-1.5-flash (Legacy models)
Any OpenRouter Model (100+ available):

anthropic/claude-3.5-sonnet, anthropic/claude-3-opus, anthropic/claude-3-haiku
openai/gpt-4o, openai/gpt-4o-mini, openai/gpt-4-turbo
google/gemini-flash-1.5-8b, google/gemini-pro
meta/llama-3.1-405b-instruct, meta/llama-3.1-70b-instruct
mistral/mistral-large, mistral/codestral-mamba
And [140+ more models](https://openrouter.ai/docs/models) across providers