### PR TITLE
fix: math rendering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ On a labeled validation set:
    - Empirical hallucination rate among answered items
    - Wilson upper bound at 95% confidence
 3. **Select smallest margin** where Wilson upper bound ≤ target $h^*$ (e.g., 5%)
-4. **Freeze policy**: $(h^*, \tau, \text{margin}, B, \text{clip\_mode}, m, r, \text{skeleton\_policy})$
+4. **Freeze policy**: $`(h^*, \tau, \text{margin}, B, \text{clip\_mode}, m, r, \text{skeleton\_policy})`$
 
 ### Portfolio Reporting
 


### PR DESCRIPTION
This PR fixes the error `'_' allowed only in math mode` in the README (in section: https://github.com/leochlon/hallbayes?tab=readme-ov-file#calibration--validation).

> There are two options for delimiting a math expression inline with your text. You can either surround the expression with dollar symbols ($), or start the expression with $` and end it with `$. The latter syntax is useful when the expression you are writing contains characters that overlap with markdown syntax.

Source: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions