### PR TITLE
feat: local-model verifier backend + fix span-normalization silent failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ Supported today:
 Not supported yet:
 - Anthropic (OpenAI-compat layer ignores `logprobs`)
 
+## Local Models
+
+Berry verifies against any OpenAI-compatible Chat Completions endpoint that returns `logprobs` + `top_logprobs` — so locally hosted models (vLLM, llama.cpp, LM Studio) work as first-class verifier backends. Point Berry at the local `base_url` and pick a model with reliable logprob support; no real API key is needed for most local servers (any non-empty string works). Run `berry doctor` to validate connectivity, logprob availability, and model selection before you start verifying.
+
+```jsonc
+// ~/.berry/mcp_env.json
+{
+  "BERRY_VERIFIER_BACKEND": "local",
+  "BERRY_VERIFIER_MODEL": "gpt-oss-20b",
+  "BERRY_LOCAL_BASE_URL": "http://127.0.0.1:1234/v1",
+  "OPENAI_API_KEY": "not-needed"
+}
+```
+
+See `docs/LOCAL-MODELS.md` for the full setup, supported servers, and calibration guidance.
+
 ## Quickstart
 
 1) Install:
@@ -66,6 +82,7 @@ berry setup
 
 - `docs/USAGE.md` — task‑oriented guides
 - `docs/CLI.md` — command reference
+- `docs/LOCAL-MODELS.md` — running Berry against locally hosted verifier models (incl. `berry doctor`)
 - `docs/CONFIGURATION.md` — config files, defaults, and env vars
 - `docs/MCP.md` — tools/prompts and transport details
 - `docs/PACKAGING.md` — release pipeline (macOS pkg + Homebrew cask)

--- a/docs/LOCAL-MODELS.md
+++ b/docs/LOCAL-MODELS.md
@@ -1,0 +1,296 @@
+# Running Berry against local models
+
+Berry's verifier (`detect_hallucination`, `audit_trace_budget`) is backend-agnostic:
+as long as the endpoint speaks OpenAI Chat Completions **and** returns `top_logprobs`
+on the first generated token, Berry can use it. That means you can run the entire
+verification loop on your own hardware.
+
+This guide covers why you'd want to, what you actually need from the runtime, how
+to wire up the three runtimes most people pick (LM Studio, vLLM, llama.cpp), and
+how to debug the small handful of things that go wrong.
+
+---
+
+## 1. Why local
+
+- **Privacy** — Berry sees your spans verbatim. With a hosted API, those spans
+  (file contents, prompts, code, internal docs) leave your machine. A local
+  endpoint keeps them inside your loopback interface.
+- **Cost** — verification on every claim adds up fast on metered APIs. A local
+  3B–20B model handles `detect_hallucination` calls indefinitely for the cost of
+  your electricity.
+- **Latency** — once a model is warm, a small verifier on Apple Silicon or a
+  single GPU answers in well under a second. Hosted endpoints rarely beat that
+  for first-token latency.
+- **Offline** — works on planes, in air-gapped environments, in CI runners
+  with no outbound network, and during third-party API outages.
+
+Trade-off: small local models hallucinate too. Berry compensates by reading
+`top_logprobs` to score *calibrated* confidence rather than trusting the model's
+top pick. That only works if the runtime actually returns logprobs — which is
+the next section.
+
+---
+
+## 2. Hard requirement: `top_logprobs`
+
+Berry's verifier asks the model a closed question and inspects the probability
+distribution over the **first** generated token. Concretely, every request looks
+like:
+
+```json
+{
+  "model": "your-model",
+  "messages": [...],
+  "max_tokens": 1,
+  "logprobs": true,
+  "top_logprobs": 5,
+  "temperature": 0.0
+}
+```
+
+And every response must include something like:
+
+```json
+{
+  "choices": [{
+    "logprobs": {
+      "content": [{
+        "token": "Yes",
+        "logprob": -0.12,
+        "top_logprobs": [
+          {"token": "Yes", "logprob": -0.12},
+          {"token": "No",  "logprob": -2.30}
+        ]
+      }]
+    }
+  }]
+}
+```
+
+If `logprobs` is `null`, missing, or the runtime silently drops `top_logprobs`,
+Berry's calibration math has nothing to work with. The verifier will either
+fall back to a degenerate score or refuse the call outright. **No top_logprobs,
+no Berry.**
+
+`berry doctor` probes for this and reports `logprobs_populated` / `top_logprobs_nonempty`.
+
+---
+
+## 3. Runtime compatibility matrix
+
+| Runtime              | `top_logprobs` | OpenAI-compat | Notes                                                                                       |
+| -------------------- | -------------- | ------------- | ------------------------------------------------------------------------------------------- |
+| **LM Studio**        | Yes (>=0.3)    | Yes           | Easiest path on Mac/Windows. GUI + headless server (`lms server start`).                    |
+| **vLLM**             | Yes            | Yes           | Production choice. Highest throughput. Requires CUDA or ROCm.                               |
+| **llama.cpp server** | Yes (>=b3000)  | Yes           | Lightest footprint. Pure CPU works. Pre-b3000 builds dropped logprobs on the chat endpoint. |
+| **MLX-LM**           | Yes (>=0.18)   | Yes (`mlx_lm.server`) | Apple Silicon native. Lower memory than llama.cpp for the same model.               |
+| **Ollama**           | **No**         | Partial       | `top_logprobs` is **not** exposed via the OpenAI-compat endpoint as of Ollama 0.5.x. Workaround: run llama.cpp server in front of the same GGUF. |
+| **sglang**           | Yes            | Yes           | Good middle ground between vLLM throughput and llama.cpp simplicity.                        |
+| **text-generation-webui** | Yes (with `--api`) | Yes  | OpenAI extension lags upstream; verify with `berry doctor` first.                           |
+
+---
+
+## 4. Setup — LM Studio (most common)
+
+### 4.1 Download a model
+
+1. Open LM Studio → **Discover** tab.
+2. Pick a small instruct model (verification doesn't need a frontier model):
+   - `lmstudio-community/Qwen2.5-7B-Instruct-GGUF` (Q4_K_M is fine)
+   - `mlx-community/gpt-oss-20b-MXFP4-Q4` (MoE, fast on Apple Silicon)
+3. Download.
+
+### 4.2 Start the server
+
+1. **Developer** tab (sometimes **Local Server**) → load model → toggle Server to Running.
+2. Default port `1234`. Endpoint: `http://localhost:1234/v1`.
+
+Headless:
+
+```bash
+lms server start
+lms load <model-name>
+```
+
+### 4.3 Point Berry at it
+
+Edit `~/.berry/mcp_env.json`:
+
+```json
+{
+  "BERRY_VERIFIER_BACKEND": "local",
+  "BERRY_VERIFIER_MODEL": "gpt-oss-20b",
+  "BERRY_LOCAL_BASE_URL": "http://127.0.0.1:1234/v1",
+  "OPENAI_API_KEY": "not-needed"
+}
+```
+
+LM Studio doesn't check `OPENAI_API_KEY`, but the SDK requires *some* value.
+
+---
+
+## 5. Setup — vLLM (production)
+
+```bash
+pip install vllm
+vllm serve openai/gpt-oss-20b \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --dtype mxfp4 \
+  --max-model-len 8192 \
+  --gpu-memory-utilization 0.85
+```
+
+`~/.berry/mcp_env.json`:
+
+```json
+{
+  "BERRY_VERIFIER_BACKEND": "local",
+  "BERRY_VERIFIER_MODEL": "openai/gpt-oss-20b",
+  "BERRY_LOCAL_BASE_URL": "http://127.0.0.1:8000/v1",
+  "OPENAI_API_KEY": "not-needed"
+}
+```
+
+vLLM exposes `top_logprobs` by default. No extra flag needed.
+
+---
+
+## 6. Setup — llama.cpp server (lightweight)
+
+```bash
+brew install llama.cpp   # or build from source
+llama-server \
+  --model /path/to/model.Q4_K_M.gguf \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --ctx-size 8192 \
+  --n-gpu-layers 999 \
+  --chat-template llama3
+```
+
+`--chat-template` matters — if the GGUF has no embedded template, omitting this
+flag will silently produce broken prompts. Common values: `llama3`, `chatml`,
+`qwen2`, `phi3`.
+
+`~/.berry/mcp_env.json`:
+
+```json
+{
+  "BERRY_VERIFIER_BACKEND": "local",
+  "BERRY_VERIFIER_MODEL": "local",
+  "BERRY_LOCAL_BASE_URL": "http://127.0.0.1:8080/v1",
+  "OPENAI_API_KEY": "not-needed"
+}
+```
+
+llama.cpp ignores `model`; pick any short label.
+
+---
+
+## 7. Verification
+
+### 7.1 `berry doctor`
+
+```bash
+berry doctor
+```
+
+Reports backend, model, base_url, HTTP status, latency, `logprobs_populated`,
+`top_logprobs_nonempty`. Exits non-zero if any of those are unhealthy.
+
+### 7.2 Manual curl
+
+```bash
+curl -s http://localhost:1234/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer not-needed" \
+  -d '{
+    "model": "gpt-oss-20b",
+    "messages": [{"role":"user","content":"Reply with only the word Yes."}],
+    "max_tokens": 1,
+    "logprobs": true,
+    "top_logprobs": 5,
+    "temperature": 0.0
+  }' | python -m json.tool
+```
+
+Look for non-null `choices[0].logprobs.content[0].top_logprobs` with >=2 entries.
+
+---
+
+## 8. Calibration
+
+Different local models calibrate differently than `gpt-4.1-nano`. Berry's
+default `verification_*_default_target = 0.95` may be unreachable for a given
+local model on supported claims, producing false-positive flags.
+
+```bash
+python scripts/calibrate_local.py \
+  --backend local \
+  --model gpt-oss-20b \
+  --base-url http://127.0.0.1:1234/v1
+```
+
+Script runs 20 known-true + 20 known-false claim/span pairs and prints the
+P(YES) histogram for each class plus a suggested threshold. Set it in
+`~/.berry/config.json`:
+
+```json
+{
+  "verification_write_default_target": 0.85,
+  "verification_output_default_target": 0.85
+}
+```
+
+Re-run calibration when you change model or quant level.
+
+---
+
+## 9. Troubleshooting
+
+### `top_logprobs` is `null` or missing
+
+- **Ollama**: not fixable on the OpenAI-compat endpoint. Switch to llama.cpp
+  pointing at the same GGUF.
+- **llama.cpp**: upgrade past b3000.
+- **LM Studio < 0.3**: update.
+- **text-generation-webui**: load the `openai` extension; verify with curl.
+
+### "Model not loaded" / 404 on every call
+
+- **LM Studio**: load a model in Developer tab or enable JIT model loading.
+- **llama.cpp**: one model per server process; restart with `--model <new>`.
+- **vLLM**: one model per server; run multiple instances on different ports.
+
+### Port already in use
+
+```bash
+lsof -iTCP:1234 -sTCP:LISTEN
+kill $(lsof -tiTCP:1234 -sTCP:LISTEN)
+```
+
+### First call takes 30+ seconds
+
+Cold-start cost. Pre-warm before benchmarking. Berry bumps `timeout_s` to 60s
+floor automatically when `base_url` is loopback.
+
+### Verifier returns plausible but wrong scores
+
+1. **Calibration mismatch** — re-run `scripts/calibrate_local.py`.
+2. **Wrong chat template** — llama.cpp / MLX-LM with no `--chat-template` will
+   produce structurally broken prompts; logprobs come back on the wrong tokens.
+3. **Temperature drift** — some runtimes ignore `temperature: 0.0`. Force it
+   server-side.
+
+### Slow throughput under parallel load
+
+- **vLLM**: `--max-num-seqs 32`.
+- **llama.cpp**: `--parallel 4` for continuous batching.
+- **LM Studio**: single-request at a time. Switch to vLLM for concurrent load.
+
+---
+
+See also `docs/CONFIGURATION.md` for the full env-var reference and
+`docs/CLI.md` for `berry doctor` / `berry setup` flags.

--- a/scripts/calibrate_local.py
+++ b/scripts/calibrate_local.py
@@ -25,7 +25,6 @@ if _SRC.is_dir() and str(_SRC) not in sys.path:
 
 from berry.hallucination_detector.core import run_detect_hallucination  # noqa: E402
 
-
 TRUE_CASES: List[Tuple[str, str]] = [
     ("Paris is the capital of France.", "Paris is the capital of France."),
     ("Water boils at 100 degrees Celsius at 1 atmosphere of pressure.",

--- a/scripts/calibrate_local.py
+++ b/scripts/calibrate_local.py
@@ -10,6 +10,7 @@ Usage:
         --model gpt-oss-20b \\
         --base-url http://127.0.0.1:1234/v1
 """
+
 from __future__ import annotations
 
 import argparse
@@ -27,84 +28,138 @@ from berry.hallucination_detector.core import run_detect_hallucination  # noqa: 
 
 TRUE_CASES: List[Tuple[str, str]] = [
     ("Paris is the capital of France.", "Paris is the capital of France."),
-    ("Water boils at 100 degrees Celsius at 1 atmosphere of pressure.",
-     "At standard atmospheric pressure of 1 atm, water boils at 100 degrees Celsius."),
+    (
+        "Water boils at 100 degrees Celsius at 1 atmosphere of pressure.",
+        "At standard atmospheric pressure of 1 atm, water boils at 100 degrees Celsius.",
+    ),
     ("The Earth orbits the Sun.", "The Earth orbits the Sun once per year."),
-    ("Mount Everest is the tallest mountain on Earth.",
-     "Mount Everest, at 8,848 meters, is the tallest mountain above sea level on Earth."),
-    ("Humans have 23 pairs of chromosomes.",
-     "A typical human cell contains 23 pairs of chromosomes."),
-    ("The Pacific Ocean is the largest ocean.",
-     "The Pacific Ocean is the largest and deepest of the world's oceans."),
-    ("World War II ended in 1945.",
-     "World War II ended in 1945 with the surrender of Japan."),
-    ("The chemical symbol for gold is Au.",
-     "Gold has the chemical symbol Au and atomic number 79."),
-    ("Light travels faster than sound.",
-     "Light travels at roughly 300,000 km/s, far faster than the speed of sound in air."),
-    ("The Great Wall of China is located in China.",
-     "The Great Wall of China stretches across northern China."),
-    ("Shakespeare wrote Hamlet.",
-     "William Shakespeare is the author of the tragedy Hamlet."),
-    ("A triangle has three sides.",
-     "By definition, every triangle is a polygon with exactly three sides."),
-    ("The human heart has four chambers.",
-     "The human heart consists of four chambers: two atria and two ventricles."),
-    ("DNA is a double helix.",
-     "DNA molecules are structured as a double helix of two complementary strands."),
-    ("The Amazon is a river in South America.",
-     "The Amazon River flows through several countries in South America."),
-    ("Mercury is the planet closest to the Sun.",
-     "Mercury is the innermost planet in the Solar System, closest to the Sun."),
-    ("Oxygen is required for human respiration.",
-     "Human cellular respiration requires oxygen to produce energy from glucose."),
-    ("English is spoken in the United Kingdom.",
-     "English is the primary language of the United Kingdom."),
-    ("The speed of light in a vacuum is approximately 300,000 km/s.",
-     "Light travels at approximately 299,792 km/s in a vacuum."),
-    ("Cats are mammals.",
-     "Domestic cats are small carnivorous mammals of the family Felidae."),
+    (
+        "Mount Everest is the tallest mountain on Earth.",
+        "Mount Everest, at 8,848 meters, is the tallest mountain above sea level on Earth.",
+    ),
+    (
+        "Humans have 23 pairs of chromosomes.",
+        "A typical human cell contains 23 pairs of chromosomes.",
+    ),
+    (
+        "The Pacific Ocean is the largest ocean.",
+        "The Pacific Ocean is the largest and deepest of the world's oceans.",
+    ),
+    ("World War II ended in 1945.", "World War II ended in 1945 with the surrender of Japan."),
+    (
+        "The chemical symbol for gold is Au.",
+        "Gold has the chemical symbol Au and atomic number 79.",
+    ),
+    (
+        "Light travels faster than sound.",
+        "Light travels at roughly 300,000 km/s, far faster than the speed of sound in air.",
+    ),
+    (
+        "The Great Wall of China is located in China.",
+        "The Great Wall of China stretches across northern China.",
+    ),
+    ("Shakespeare wrote Hamlet.", "William Shakespeare is the author of the tragedy Hamlet."),
+    (
+        "A triangle has three sides.",
+        "By definition, every triangle is a polygon with exactly three sides.",
+    ),
+    (
+        "The human heart has four chambers.",
+        "The human heart consists of four chambers: two atria and two ventricles.",
+    ),
+    (
+        "DNA is a double helix.",
+        "DNA molecules are structured as a double helix of two complementary strands.",
+    ),
+    (
+        "The Amazon is a river in South America.",
+        "The Amazon River flows through several countries in South America.",
+    ),
+    (
+        "Mercury is the planet closest to the Sun.",
+        "Mercury is the innermost planet in the Solar System, closest to the Sun.",
+    ),
+    (
+        "Oxygen is required for human respiration.",
+        "Human cellular respiration requires oxygen to produce energy from glucose.",
+    ),
+    (
+        "English is spoken in the United Kingdom.",
+        "English is the primary language of the United Kingdom.",
+    ),
+    (
+        "The speed of light in a vacuum is approximately 300,000 km/s.",
+        "Light travels at approximately 299,792 km/s in a vacuum.",
+    ),
+    ("Cats are mammals.", "Domestic cats are small carnivorous mammals of the family Felidae."),
 ]
 
 FALSE_CASES: List[Tuple[str, str]] = [
     ("Paris is the capital of Germany.", "Paris is the capital of France."),
-    ("Water boils at 50 degrees Celsius at 1 atmosphere.",
-     "Water boils at 100 degrees Celsius at 1 atm of pressure."),
+    (
+        "Water boils at 50 degrees Celsius at 1 atmosphere.",
+        "Water boils at 100 degrees Celsius at 1 atm of pressure.",
+    ),
     ("The Sun orbits the Earth.", "The Earth orbits the Sun once per year."),
-    ("Mount Everest is in Australia.",
-     "Mount Everest is located on the border between Nepal and Tibet."),
-    ("Humans have 50 pairs of chromosomes.",
-     "A typical human cell contains 23 pairs of chromosomes."),
-    ("The Atlantic Ocean is the largest ocean on Earth.",
-     "The Pacific Ocean is the largest and deepest of the world's oceans."),
-    ("World War II ended in 1965.",
-     "World War II ended in 1945 with the surrender of Japan."),
-    ("The chemical symbol for gold is Go.",
-     "Gold has the chemical symbol Au and atomic number 79."),
-    ("Sound travels faster than light.",
-     "Light travels at roughly 300,000 km/s, far faster than the speed of sound in air."),
-    ("The Great Wall of China is located in Brazil.",
-     "The Great Wall of China stretches across northern China."),
-    ("Charles Dickens wrote Hamlet.",
-     "William Shakespeare is the author of the tragedy Hamlet."),
-    ("A triangle has five sides.",
-     "By definition, every triangle is a polygon with exactly three sides."),
-    ("The human heart has two chambers.",
-     "The human heart consists of four chambers: two atria and two ventricles."),
-    ("DNA is a single strand.",
-     "DNA molecules are structured as a double helix of two complementary strands."),
-    ("The Amazon is a river in Europe.",
-     "The Amazon River flows through several countries in South America."),
-    ("Jupiter is the planet closest to the Sun.",
-     "Mercury is the innermost planet in the Solar System, closest to the Sun."),
-    ("Nitrogen alone is sufficient for human cellular respiration.",
-     "Human cellular respiration requires oxygen to produce energy from glucose."),
-    ("Mandarin is the primary language of the United Kingdom.",
-     "English is the primary language of the United Kingdom."),
-    ("Light travels at approximately 3 km/s in a vacuum.",
-     "Light travels at approximately 299,792 km/s in a vacuum."),
-    ("Cats are reptiles.",
-     "Domestic cats are small carnivorous mammals of the family Felidae."),
+    (
+        "Mount Everest is in Australia.",
+        "Mount Everest is located on the border between Nepal and Tibet.",
+    ),
+    (
+        "Humans have 50 pairs of chromosomes.",
+        "A typical human cell contains 23 pairs of chromosomes.",
+    ),
+    (
+        "The Atlantic Ocean is the largest ocean on Earth.",
+        "The Pacific Ocean is the largest and deepest of the world's oceans.",
+    ),
+    ("World War II ended in 1965.", "World War II ended in 1945 with the surrender of Japan."),
+    (
+        "The chemical symbol for gold is Go.",
+        "Gold has the chemical symbol Au and atomic number 79.",
+    ),
+    (
+        "Sound travels faster than light.",
+        "Light travels at roughly 300,000 km/s, far faster than the speed of sound in air.",
+    ),
+    (
+        "The Great Wall of China is located in Brazil.",
+        "The Great Wall of China stretches across northern China.",
+    ),
+    ("Charles Dickens wrote Hamlet.", "William Shakespeare is the author of the tragedy Hamlet."),
+    (
+        "A triangle has five sides.",
+        "By definition, every triangle is a polygon with exactly three sides.",
+    ),
+    (
+        "The human heart has two chambers.",
+        "The human heart consists of four chambers: two atria and two ventricles.",
+    ),
+    (
+        "DNA is a single strand.",
+        "DNA molecules are structured as a double helix of two complementary strands.",
+    ),
+    (
+        "The Amazon is a river in Europe.",
+        "The Amazon River flows through several countries in South America.",
+    ),
+    (
+        "Jupiter is the planet closest to the Sun.",
+        "Mercury is the innermost planet in the Solar System, closest to the Sun.",
+    ),
+    (
+        "Nitrogen alone is sufficient for human cellular respiration.",
+        "Human cellular respiration requires oxygen to produce energy from glucose.",
+    ),
+    (
+        "Mandarin is the primary language of the United Kingdom.",
+        "English is the primary language of the United Kingdom.",
+    ),
+    (
+        "Light travels at approximately 3 km/s in a vacuum.",
+        "Light travels at approximately 299,792 km/s in a vacuum.",
+    ),
+    ("Cats are reptiles.", "Domestic cats are small carnivorous mammals of the family Felidae."),
 ]
 
 
@@ -160,7 +215,11 @@ def _histogram(label: str, probs: List[float], *, width: int = 40) -> None:
     if probs:
         mean = sum(probs) / len(probs)
         srt = sorted(probs)
-        median = srt[len(srt) // 2] if len(srt) % 2 else 0.5 * (srt[len(srt) // 2 - 1] + srt[len(srt) // 2])
+        median = (
+            srt[len(srt) // 2]
+            if len(srt) % 2
+            else 0.5 * (srt[len(srt) // 2 - 1] + srt[len(srt) // 2])
+        )
         print(f"  mean={mean:.3f}  median={median:.3f}  min={min(probs):.3f}  max={max(probs):.3f}")
 
 
@@ -182,13 +241,17 @@ def _suggest_threshold(true_p: List[float], false_p: List[float]) -> Tuple[float
 def parse_args(argv: List[str]) -> argparse.Namespace:
     env_backend = (os.environ.get("BERRY_VERIFIER_BACKEND") or "openai").strip().lower()
     p = argparse.ArgumentParser(description="Calibrate Berry verifier thresholds.")
-    p.add_argument("--backend", choices=["openai", "local", "gemini", "vertex"],
-                   default=env_backend if env_backend in {"openai", "local", "gemini", "vertex"} else "openai")
+    p.add_argument(
+        "--backend",
+        choices=["openai", "local", "gemini", "vertex"],
+        default=env_backend if env_backend in {"openai", "local", "gemini", "vertex"} else "openai",
+    )
     p.add_argument("--model", required=True)
     p.add_argument("--base-url", default="")
     p.add_argument("--api-key", default="")
-    p.add_argument("--limit", type=int, default=0,
-                   help="If >0, run only the first N items from each set.")
+    p.add_argument(
+        "--limit", type=int, default=0, help="If >0, run only the first N items from each set."
+    )
     return p.parse_args(argv)
 
 

--- a/scripts/calibrate_local.py
+++ b/scripts/calibrate_local.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Calibrate verification thresholds for a Berry verifier backend.
+
+Runs a fixed 20-true + 20-false claim set against the configured backend
+and reports the P(YES) distribution plus a suggested
+`verification_*_default_target` value for ~/.berry/config.json.
+
+Usage:
+    python scripts/calibrate_local.py --backend local \\
+        --model gpt-oss-20b \\
+        --base-url http://127.0.0.1:1234/v1
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if _SRC.is_dir() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from berry.hallucination_detector.core import run_detect_hallucination  # noqa: E402
+
+
+TRUE_CASES: List[Tuple[str, str]] = [
+    ("Paris is the capital of France.", "Paris is the capital of France."),
+    ("Water boils at 100 degrees Celsius at 1 atmosphere of pressure.",
+     "At standard atmospheric pressure of 1 atm, water boils at 100 degrees Celsius."),
+    ("The Earth orbits the Sun.", "The Earth orbits the Sun once per year."),
+    ("Mount Everest is the tallest mountain on Earth.",
+     "Mount Everest, at 8,848 meters, is the tallest mountain above sea level on Earth."),
+    ("Humans have 23 pairs of chromosomes.",
+     "A typical human cell contains 23 pairs of chromosomes."),
+    ("The Pacific Ocean is the largest ocean.",
+     "The Pacific Ocean is the largest and deepest of the world's oceans."),
+    ("World War II ended in 1945.",
+     "World War II ended in 1945 with the surrender of Japan."),
+    ("The chemical symbol for gold is Au.",
+     "Gold has the chemical symbol Au and atomic number 79."),
+    ("Light travels faster than sound.",
+     "Light travels at roughly 300,000 km/s, far faster than the speed of sound in air."),
+    ("The Great Wall of China is located in China.",
+     "The Great Wall of China stretches across northern China."),
+    ("Shakespeare wrote Hamlet.",
+     "William Shakespeare is the author of the tragedy Hamlet."),
+    ("A triangle has three sides.",
+     "By definition, every triangle is a polygon with exactly three sides."),
+    ("The human heart has four chambers.",
+     "The human heart consists of four chambers: two atria and two ventricles."),
+    ("DNA is a double helix.",
+     "DNA molecules are structured as a double helix of two complementary strands."),
+    ("The Amazon is a river in South America.",
+     "The Amazon River flows through several countries in South America."),
+    ("Mercury is the planet closest to the Sun.",
+     "Mercury is the innermost planet in the Solar System, closest to the Sun."),
+    ("Oxygen is required for human respiration.",
+     "Human cellular respiration requires oxygen to produce energy from glucose."),
+    ("English is spoken in the United Kingdom.",
+     "English is the primary language of the United Kingdom."),
+    ("The speed of light in a vacuum is approximately 300,000 km/s.",
+     "Light travels at approximately 299,792 km/s in a vacuum."),
+    ("Cats are mammals.",
+     "Domestic cats are small carnivorous mammals of the family Felidae."),
+]
+
+FALSE_CASES: List[Tuple[str, str]] = [
+    ("Paris is the capital of Germany.", "Paris is the capital of France."),
+    ("Water boils at 50 degrees Celsius at 1 atmosphere.",
+     "Water boils at 100 degrees Celsius at 1 atm of pressure."),
+    ("The Sun orbits the Earth.", "The Earth orbits the Sun once per year."),
+    ("Mount Everest is in Australia.",
+     "Mount Everest is located on the border between Nepal and Tibet."),
+    ("Humans have 50 pairs of chromosomes.",
+     "A typical human cell contains 23 pairs of chromosomes."),
+    ("The Atlantic Ocean is the largest ocean on Earth.",
+     "The Pacific Ocean is the largest and deepest of the world's oceans."),
+    ("World War II ended in 1965.",
+     "World War II ended in 1945 with the surrender of Japan."),
+    ("The chemical symbol for gold is Go.",
+     "Gold has the chemical symbol Au and atomic number 79."),
+    ("Sound travels faster than light.",
+     "Light travels at roughly 300,000 km/s, far faster than the speed of sound in air."),
+    ("The Great Wall of China is located in Brazil.",
+     "The Great Wall of China stretches across northern China."),
+    ("Charles Dickens wrote Hamlet.",
+     "William Shakespeare is the author of the tragedy Hamlet."),
+    ("A triangle has five sides.",
+     "By definition, every triangle is a polygon with exactly three sides."),
+    ("The human heart has two chambers.",
+     "The human heart consists of four chambers: two atria and two ventricles."),
+    ("DNA is a single strand.",
+     "DNA molecules are structured as a double helix of two complementary strands."),
+    ("The Amazon is a river in Europe.",
+     "The Amazon River flows through several countries in South America."),
+    ("Jupiter is the planet closest to the Sun.",
+     "Mercury is the innermost planet in the Solar System, closest to the Sun."),
+    ("Nitrogen alone is sufficient for human cellular respiration.",
+     "Human cellular respiration requires oxygen to produce energy from glucose."),
+    ("Mandarin is the primary language of the United Kingdom.",
+     "English is the primary language of the United Kingdom."),
+    ("Light travels at approximately 3 km/s in a vacuum.",
+     "Light travels at approximately 299,792 km/s in a vacuum."),
+    ("Cats are reptiles.",
+     "Domestic cats are small carnivorous mammals of the family Felidae."),
+]
+
+
+def _configure_env(backend: str, base_url: str, api_key: str) -> None:
+    backend = (backend or "openai").strip().lower()
+    if backend == "local":
+        os.environ["BERRY_VERIFIER_BACKEND"] = "local"
+        if base_url:
+            os.environ["BERRY_LOCAL_BASE_URL"] = base_url
+    else:
+        os.environ["BERRY_VERIFIER_BACKEND"] = backend
+        if base_url:
+            os.environ["BERRY_OPENAI_BASE_URL"] = base_url
+    if api_key:
+        os.environ["OPENAI_API_KEY"] = api_key
+    elif not os.environ.get("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = "not-needed"
+
+
+def _score_one(claim: str, span_text: str, *, model: str) -> float:
+    result = run_detect_hallucination(
+        answer=claim,
+        spans=[{"sid": "S1", "text": span_text}],
+        verifier_model=model,
+        default_target=0.95,
+        max_claims=1,
+        temperature=0.0,
+        top_logprobs=10,
+        max_concurrency=1,
+        timeout_s=60.0,
+        units="bits",
+    )
+    details = result.get("details") or []
+    if not details:
+        return float("nan")
+    return float((details[0].get("post_yes") or {}).get("p_lower") or 0.0)
+
+
+def _histogram(label: str, probs: List[float], *, width: int = 40) -> None:
+    bins = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0001]
+    counts = [0] * (len(bins) - 1)
+    for p in probs:
+        for i in range(len(bins) - 1):
+            if bins[i] <= p < bins[i + 1]:
+                counts[i] += 1
+                break
+    peak = max(counts) or 1
+    print(f"\n{label} (n={len(probs)})")
+    for i in range(len(bins) - 1):
+        lo, hi = bins[i], bins[i + 1]
+        bar = "#" * int(round(counts[i] / peak * width))
+        print(f"  [{lo:.1f}, {hi:.1f}) | {bar:<{width}} {counts[i]}")
+    if probs:
+        mean = sum(probs) / len(probs)
+        srt = sorted(probs)
+        median = srt[len(srt) // 2] if len(srt) % 2 else 0.5 * (srt[len(srt) // 2 - 1] + srt[len(srt) // 2])
+        print(f"  mean={mean:.3f}  median={median:.3f}  min={min(probs):.3f}  max={max(probs):.3f}")
+
+
+def _suggest_threshold(true_p: List[float], false_p: List[float]) -> Tuple[float, float, float]:
+    best = (0.95, 0.0, 0.0, -1.0)
+    n_true = max(1, len(true_p))
+    n_false = max(1, len(false_p))
+    T = 0.50
+    while T <= 0.991:
+        tpr = sum(1 for p in true_p if p >= T) / n_true
+        frr = sum(1 for p in false_p if p < T) / n_false
+        score = tpr * frr
+        if score > best[3] or (abs(score - best[3]) < 1e-9 and T > best[0]):
+            best = (round(T, 2), tpr, frr, score)
+        T += 0.01
+    return best[0], best[1], best[2]
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    env_backend = (os.environ.get("BERRY_VERIFIER_BACKEND") or "openai").strip().lower()
+    p = argparse.ArgumentParser(description="Calibrate Berry verifier thresholds.")
+    p.add_argument("--backend", choices=["openai", "local", "gemini", "vertex"],
+                   default=env_backend if env_backend in {"openai", "local", "gemini", "vertex"} else "openai")
+    p.add_argument("--model", required=True)
+    p.add_argument("--base-url", default="")
+    p.add_argument("--api-key", default="")
+    p.add_argument("--limit", type=int, default=0,
+                   help="If >0, run only the first N items from each set.")
+    return p.parse_args(argv)
+
+
+def main(argv: List[str]) -> int:
+    args = parse_args(argv)
+    _configure_env(args.backend, args.base_url, args.api_key)
+
+    trues = TRUE_CASES if args.limit <= 0 else TRUE_CASES[: args.limit]
+    falses = FALSE_CASES if args.limit <= 0 else FALSE_CASES[: args.limit]
+
+    print(f"Backend: {args.backend}  model: {args.model}  base_url: {args.base_url or '(default)'}")
+    print(f"Running {len(trues)} true and {len(falses)} false cases...\n")
+
+    true_p: List[float] = []
+    for i, (claim, span) in enumerate(trues, 1):
+        p = _score_one(claim, span, model=args.model)
+        true_p.append(p)
+        print(f"  T{i:02d}  P(YES)={p:.3f}  {claim[:60]}")
+
+    false_p: List[float] = []
+    for i, (claim, span) in enumerate(falses, 1):
+        p = _score_one(claim, span, model=args.model)
+        false_p.append(p)
+        print(f"  F{i:02d}  P(YES)={p:.3f}  {claim[:60]}")
+
+    _histogram("TRUE  claims P(YES)", true_p)
+    _histogram("FALSE claims P(YES)", false_p)
+
+    T, tpr, frr = _suggest_threshold(true_p, false_p)
+    overlap = sum(1 for p in false_p if p >= T) + sum(1 for p in true_p if p < T)
+
+    print("\n=== Calibration summary ===")
+    print(f"  Suggested threshold T          : {T:.2f}")
+    print(f"  True  pass rate  (P>=T)        : {tpr:.2%}")
+    print(f"  False reject rate (P<T)        : {frr:.2%}")
+    print(f"  Misclassified items            : {overlap}/{len(true_p) + len(false_p)}")
+    print(f"  Score (tpr * frr)              : {tpr * frr:.3f}")
+
+    print("\nRecommendation:")
+    print(f"  Set verification_write_default_target  to {T:.2f} in ~/.berry/config.json")
+    print(f"  Set verification_output_default_target to {T:.2f} in ~/.berry/config.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/berry/cli.py
+++ b/src/berry/cli.py
@@ -245,7 +245,9 @@ def cmd_doctor(_: argparse.Namespace) -> int:
     elif backend == "vertex":
         base_url = (env.get("VERTEX_BASE_URL") or "").strip() or None
     else:
-        base_url = (env.get("BERRY_OPENAI_BASE_URL") or env.get("OPENAI_BASE_URL") or "").strip() or None
+        base_url = (
+            env.get("BERRY_OPENAI_BASE_URL") or env.get("OPENAI_BASE_URL") or ""
+        ).strip() or None
 
     report: dict = {
         "python": sys.version.split()[0],

--- a/src/berry/cli.py
+++ b/src/berry/cli.py
@@ -223,22 +223,107 @@ def cmd_init(args: argparse.Namespace) -> int:
 
 
 def cmd_doctor(_: argparse.Namespace) -> int:
+    """Verify backend health: config, then a tiny logprobs-enabled ping.
+
+    Reports backend kind, model, base_url (if applicable), HTTP status,
+    latency ms, and whether logprobs / top_logprobs are populated.
+    Exits 0 on success, 1 on any failure.
+    """
+    import time
+
     project_root = _find_repo_root(Path.cwd())
     cfg = load_config(project_root=project_root)
 
-    checks = {
+    env = _load_env_file(mcp_env_path())
+    backend = (env.get("BERRY_VERIFIER_BACKEND") or "openai").strip() or "openai"
+    model = (env.get("BERRY_VERIFIER_MODEL") or env.get("BERRY_MODEL") or "").strip()
+
+    if backend == "local":
+        base_url = (env.get("BERRY_LOCAL_BASE_URL") or "http://127.0.0.1:1234/v1").strip() or None
+    elif backend == "gemini":
+        base_url = (env.get("GEMINI_BASE_URL") or "").strip() or None
+    elif backend == "vertex":
+        base_url = (env.get("VERTEX_BASE_URL") or "").strip() or None
+    else:
+        base_url = (env.get("BERRY_OPENAI_BASE_URL") or env.get("OPENAI_BASE_URL") or "").strip() or None
+
+    report: dict = {
         "python": sys.version.split()[0],
         "project_root": str(project_root),
-        "allow_write": cfg.allow_write,
-        "allow_exec": cfg.allow_exec,
-        "allow_web": cfg.allow_web,
-        "enforce_verification": cfg.enforce_verification,
-        "require_plan_approval": cfg.require_plan_approval,
-        "audit_log_enabled": cfg.audit_log_enabled,
-        "diagnostics_opt_in": cfg.diagnostics_opt_in,
+        "config": {
+            "allow_write": cfg.allow_write,
+            "allow_exec": cfg.allow_exec,
+            "allow_web": cfg.allow_web,
+            "enforce_verification": cfg.enforce_verification,
+            "require_plan_approval": cfg.require_plan_approval,
+            "audit_log_enabled": cfg.audit_log_enabled,
+            "diagnostics_opt_in": cfg.diagnostics_opt_in,
+        },
+        "backend": backend,
+        "model": model,
+        "base_url": base_url,
     }
-    print(json.dumps(checks, indent=2))
-    return 0
+
+    if not model:
+        report["ping"] = {"ok": False, "error": "no verifier model configured; run `berry setup`"}
+        print(json.dumps(report, indent=2))
+        return 1
+
+    prompt = "Answer YES or NO: Is the sky typically blue during the day?"
+    api_key = (env.get("OPENAI_API_KEY") or "").strip()
+
+    t0 = time.monotonic()
+    http_status = "n/a"
+    logprobs_populated = False
+    top_logprobs_nonempty = False
+    err: Optional[str] = None
+
+    try:
+        if backend in ("openai", "local"):
+            try:
+                from openai import OpenAI
+            except Exception as e:
+                raise RuntimeError(f"openai SDK not available: {e}")
+            if backend == "openai" and not api_key:
+                raise RuntimeError("OPENAI_API_KEY missing")
+            effective_key = api_key or "not-needed"
+            kwargs = {"api_key": effective_key, "timeout": 30}
+            if base_url:
+                kwargs["base_url"] = base_url
+            client = OpenAI(**kwargs)
+            resp = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0,
+                max_tokens=4,
+                logprobs=True,
+                top_logprobs=5,
+            )
+            http_status = 200
+            choice = resp.choices[0]
+            lp = getattr(choice, "logprobs", None)
+            content = getattr(lp, "content", None) if lp is not None else None
+            logprobs_populated = bool(content)
+            if content:
+                top = getattr(content[0], "top_logprobs", None)
+                top_logprobs_nonempty = bool(top)
+        else:
+            raise RuntimeError(f"unsupported backend for ping: {backend}")
+    except Exception as e:
+        err = f"{type(e).__name__}: {e}"
+
+    latency_ms = int((time.monotonic() - t0) * 1000)
+    ok = err is None and logprobs_populated and top_logprobs_nonempty
+    report["ping"] = {
+        "ok": ok,
+        "http_status": http_status,
+        "latency_ms": latency_ms,
+        "logprobs_populated": logprobs_populated,
+        "top_logprobs_nonempty": top_logprobs_nonempty,
+        "error": err,
+    }
+    print(json.dumps(report, indent=2))
+    return 0 if ok else 1
 
 
 def cmd_status(_: argparse.Namespace) -> int:

--- a/src/berry/cli.py
+++ b/src/berry/cli.py
@@ -7,7 +7,7 @@ import os
 import sys
 from dataclasses import asdict, replace
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from . import __version__
 from .audit import export_events, prune_events
@@ -275,7 +275,7 @@ def cmd_doctor(_: argparse.Namespace) -> int:
     api_key = (env.get("OPENAI_API_KEY") or "").strip()
 
     t0 = time.monotonic()
-    http_status = "n/a"
+    http_status: Any = "n/a"
     logprobs_populated = False
     top_logprobs_nonempty = False
     err: Optional[str] = None
@@ -289,10 +289,10 @@ def cmd_doctor(_: argparse.Namespace) -> int:
             if backend == "openai" and not api_key:
                 raise RuntimeError("OPENAI_API_KEY missing")
             effective_key = api_key or "not-needed"
-            kwargs = {"api_key": effective_key, "timeout": 30}
+            client_kwargs: dict[str, Any] = {"api_key": effective_key, "timeout": 30}
             if base_url:
-                kwargs["base_url"] = base_url
-            client = OpenAI(**kwargs)
+                client_kwargs["base_url"] = base_url
+            client = OpenAI(**client_kwargs)
             resp = client.chat.completions.create(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],

--- a/src/berry/config.py
+++ b/src/berry/config.py
@@ -75,6 +75,11 @@ class BerryConfig:
     # Product flags (paid layer)
     paid_features_enabled: bool = False
 
+    # Verifier backend (used by hallucination/verification calls)
+    verifier_backend: str = "openai"  # choices: openai, gemini, vertex, local
+    verifier_model: Optional[str] = None  # resolved at call time if None
+    local_base_url: str = "http://127.0.0.1:1234/v1"
+
 
 def _load_json(path: Path) -> Dict[str, Any]:
     try:
@@ -123,6 +128,13 @@ def _coerce(cfg: Dict[str, Any]) -> BerryConfig:
         audit_log_enabled=bool(cfg.get("audit_log_enabled", True)),
         audit_log_retention_days=int(cfg.get("audit_log_retention_days", 30)),
         paid_features_enabled=bool(cfg.get("paid_features_enabled", False)),
+        verifier_backend=str(cfg.get("verifier_backend", "openai")),
+        verifier_model=(
+            None
+            if cfg.get("verifier_model") in {None, ""}
+            else str(cfg.get("verifier_model"))
+        ),
+        local_base_url=str(cfg.get("local_base_url", "http://127.0.0.1:1234/v1")),
     )
 
 
@@ -161,6 +173,18 @@ def load_config(project_root: Optional[Path] = None) -> BerryConfig:
     env_exec_net = os.environ.get("BERRY_EXEC_NETWORK_MODE")
     if env_exec_net is not None and env_exec_net.strip() != "":
         cfg = replace(cfg, exec_network_mode=str(env_exec_net).strip())
+
+    env_verifier_backend = os.environ.get("BERRY_VERIFIER_BACKEND")
+    if env_verifier_backend is not None and env_verifier_backend.strip() != "":
+        cfg = replace(cfg, verifier_backend=str(env_verifier_backend).strip())
+
+    env_verifier_model = os.environ.get("BERRY_VERIFIER_MODEL")
+    if env_verifier_model is not None and env_verifier_model.strip() != "":
+        cfg = replace(cfg, verifier_model=str(env_verifier_model).strip())
+
+    env_local_base_url = os.environ.get("BERRY_LOCAL_BASE_URL")
+    if env_local_base_url is not None and env_local_base_url.strip() != "":
+        cfg = replace(cfg, local_base_url=str(env_local_base_url).strip())
 
     return cfg
 

--- a/src/berry/config.py
+++ b/src/berry/config.py
@@ -130,9 +130,7 @@ def _coerce(cfg: Dict[str, Any]) -> BerryConfig:
         paid_features_enabled=bool(cfg.get("paid_features_enabled", False)),
         verifier_backend=str(cfg.get("verifier_backend", "openai")),
         verifier_model=(
-            None
-            if cfg.get("verifier_model") in {None, ""}
-            else str(cfg.get("verifier_model"))
+            None if cfg.get("verifier_model") in {None, ""} else str(cfg.get("verifier_model"))
         ),
         local_base_url=str(cfg.get("local_base_url", "http://127.0.0.1:1234/v1")),
     )

--- a/src/berry/hallucination_detector/backends/base.py
+++ b/src/berry/hallucination_detector/backends/base.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, List, Optional, Sequence
 
 from .gemini_backend import call_text_chat_gemini
+from .local_backend import call_text_chat_local
 from .openai_backend import TextResult, call_text_chat
 from .vertex_backend import call_text_chat_vertex
 
@@ -97,8 +98,35 @@ class GeminiBackend:
         gc.collect()
 
 
+class LocalBackend:
+    """Thin wrapper around local backend with batch helpers (thread-pool parallelism)."""
+
+    def __init__(self, cfg: BackendConfig):
+        self.cfg = cfg
+
+    def call_text(self, **kwargs: Any) -> TextResult:
+        return call_text_chat_local(
+            **kwargs,
+            timeout_s=self.cfg.timeout_s,
+            base_url=self.cfg.base_url,
+            api_key=self.cfg.api_key,
+        )
+
+    def call_text_batch(self, *, prompts: Sequence[str], **kwargs: Any) -> List[TextResult]:
+        max_workers = max(1, int(self.cfg.max_concurrency))
+        with cf.ThreadPoolExecutor(max_workers=max_workers) as ex:
+            futs = [ex.submit(self.call_text, prompt=p, **kwargs) for p in prompts]
+            return [f.result() for f in futs]
+
+    def reset_state(self) -> None:
+        import gc
+        gc.collect()
+
+
 def make_backend(cfg: BackendConfig):
     kind = (cfg.kind or "openai").lower().strip()
+    if kind == "local":
+        return LocalBackend(cfg)
     if kind == "openai":
         return OpenAIBackend(cfg)
     if kind == "gemini":

--- a/src/berry/hallucination_detector/backends/base.py
+++ b/src/berry/hallucination_detector/backends/base.py
@@ -120,6 +120,7 @@ class LocalBackend:
 
     def reset_state(self) -> None:
         import gc
+
         gc.collect()
 
 

--- a/src/berry/hallucination_detector/backends/local_backend.py
+++ b/src/berry/hallucination_detector/backends/local_backend.py
@@ -25,7 +25,6 @@ from typing import Any, Dict, List, Optional
 
 from .openai_backend import TextResult
 
-
 _DEFAULT_BASE_URL = "http://127.0.0.1:1234/v1"
 _DEFAULT_API_KEY = "local"  # most local runtimes accept any non-empty value
 

--- a/src/berry/hallucination_detector/backends/local_backend.py
+++ b/src/berry/hallucination_detector/backends/local_backend.py
@@ -1,0 +1,154 @@
+"""Local OpenAI-compatible backend for Berry.
+
+Targets local model runtimes that expose /v1/chat/completions:
+  - LM Studio (default http://127.0.0.1:1234/v1)
+  - llama.cpp server
+  - vLLM (OpenAI-compatible mode)
+
+Why bypass the `openai` SDK:
+  - Avoid SDK quirks (header coercion, retry surprises, base_url precedence).
+  - Keep this backend dependency-light (stdlib only).
+  - Tolerate runtimes that aren't 100% openai-spec-compatible (e.g. slightly
+    different field shapes) by parsing the raw JSON ourselves.
+
+Response is normalized into the same `TextResult` shape as openai_backend so
+callers can swap backends without branching on field layout.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional
+
+from .openai_backend import TextResult
+
+
+_DEFAULT_BASE_URL = "http://127.0.0.1:1234/v1"
+_DEFAULT_API_KEY = "local"  # most local runtimes accept any non-empty value
+
+
+def _resolve_base_url(base_url: Optional[str]) -> str:
+    if base_url:
+        return base_url.rstrip("/")
+    env = (os.environ.get("BERRY_LOCAL_BASE_URL") or "").strip()
+    return (env or _DEFAULT_BASE_URL).rstrip("/")
+
+
+def _resolve_api_key(api_key: Optional[str]) -> str:
+    if api_key:
+        return api_key
+    env = (os.environ.get("BERRY_LOCAL_API_KEY") or "").strip()
+    return env or _DEFAULT_API_KEY
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """Retry on connection errors and 5xx HTTP responses."""
+    if isinstance(exc, urllib.error.HTTPError):
+        return 500 <= exc.code < 600
+    if isinstance(exc, urllib.error.URLError):
+        return True
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return True
+    return False
+
+
+def _normalize_logprobs(raw: Any) -> Optional[List[Dict[str, Any]]]:
+    """Convert raw /v1/chat/completions logprobs.content into our list-of-dicts shape.
+
+    Matches the structure produced by openai_backend.call_text_chat:
+      [{"token": str, "logprob": float, "top_logprobs": [{"token", "logprob"}, ...]}]
+    """
+    if not raw:
+        return None
+    content = raw.get("content") if isinstance(raw, dict) else None
+    if not content:
+        return None
+    out: List[Dict[str, Any]] = []
+    for token_info in content:
+        if not isinstance(token_info, dict):
+            continue
+        entry: Dict[str, Any] = {
+            "token": token_info.get("token", ""),
+            "logprob": token_info.get("logprob", 0.0),
+        }
+        tops = token_info.get("top_logprobs") or []
+        if tops:
+            entry["top_logprobs"] = [
+                {"token": t.get("token", ""), "logprob": t.get("logprob", 0.0)}
+                for t in tops if isinstance(t, dict)
+            ]
+        out.append(entry)
+    return out
+
+
+def call_text_chat_local(
+    *,
+    prompt: str,
+    model: str,
+    instructions: str = "You are a helpful assistant.",
+    temperature: float = 0.0,
+    max_output_tokens: int = 64,
+    include_logprobs: bool = False,
+    top_logprobs: int = 0,
+    retries: int = 3,
+    retry_backoff_s: float = 1.5,
+    timeout_s: Optional[float] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    **_kwargs: Any,
+) -> TextResult:
+    """Call a local OpenAI-compatible chat completions endpoint."""
+    if top_logprobs < 0 or top_logprobs > 20:
+        raise ValueError("top_logprobs must be between 0 and 20")
+
+    url = f"{_resolve_base_url(base_url)}/chat/completions"
+    key = _resolve_api_key(api_key)
+
+    body: Dict[str, Any] = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": instructions},
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": float(temperature),
+        "max_tokens": max(16, int(max_output_tokens)),
+    }
+    if include_logprobs:
+        body["logprobs"] = True
+        body["top_logprobs"] = int(top_logprobs)
+
+    payload = json.dumps(body).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {key}",
+    }
+
+    last_err: Optional[Exception] = None
+    for attempt in range(retries + 1):
+        try:
+            req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+                raw = resp.read().decode("utf-8")
+            data = json.loads(raw)
+            choices = data.get("choices") or []
+            if not choices:
+                raise RuntimeError(f"local backend returned no choices: {raw[:200]}")
+            choice = choices[0]
+            message = choice.get("message") or {}
+            out_text = message.get("content") or ""
+            out_logprobs = _normalize_logprobs(choice.get("logprobs")) if include_logprobs else None
+            return TextResult(
+                text=str(out_text),
+                response_id=data.get("id"),
+                logprobs=out_logprobs,
+            )
+        except Exception as e:
+            last_err = e
+            if attempt >= retries or not _is_retryable(e):
+                break
+            time.sleep(float(retry_backoff_s) * (attempt + 1))
+
+    raise RuntimeError(f"Local chat call to {url} failed after retries: {last_err}")

--- a/src/berry/hallucination_detector/backends/local_backend.py
+++ b/src/berry/hallucination_detector/backends/local_backend.py
@@ -14,6 +14,7 @@ Why bypass the `openai` SDK:
 Response is normalized into the same `TextResult` shape as openai_backend so
 callers can swap backends without branching on field layout.
 """
+
 from __future__ import annotations
 
 import json
@@ -77,7 +78,8 @@ def _normalize_logprobs(raw: Any) -> Optional[List[Dict[str, Any]]]:
         if tops:
             entry["top_logprobs"] = [
                 {"token": t.get("token", ""), "logprob": t.get("logprob", 0.0)}
-                for t in tops if isinstance(t, dict)
+                for t in tops
+                if isinstance(t, dict)
             ]
         out.append(entry)
     return out

--- a/src/berry/hallucination_detector/backends/openai_backend.py
+++ b/src/berry/hallucination_detector/backends/openai_backend.py
@@ -116,31 +116,29 @@ def call_text_chat(
             choice = resp.choices[0]
             out_text = choice.message.content or ""
 
-            out_logprobs = None
-            if (
-                include_logprobs
-                and getattr(choice, "logprobs", None)
-                and getattr(choice.logprobs, "content", None)
-            ):
-                out_logprobs = []
-                for token_info in choice.logprobs.content:
-                    token_data = {
-                        "token": token_info.token,
-                        "logprob": token_info.logprob,
-                    }
-                    if token_info.top_logprobs:
-                        token_data["top_logprobs"] = [
-                            {"token": t.token, "logprob": t.logprob}
-                            for t in token_info.top_logprobs
-                        ]
-                    out_logprobs.append(token_data)
-
-            if include_logprobs and out_logprobs is None:
-                logger.warning(
-                    "OpenAI backend at base_url=%r returned no logprobs despite logprobs=true; "
-                    "downstream calibration will degrade. Verify the server supports logprobs.",
-                    base_url,
-                )
+            out_logprobs: Optional[list] = None
+            if include_logprobs:
+                raw_lp = getattr(choice, "logprobs", None)
+                raw_content = getattr(raw_lp, "content", None) if raw_lp else None
+                if raw_content:
+                    out_logprobs = []
+                    for token_info in raw_content:
+                        token_data: Dict[str, Any] = {
+                            "token": token_info.token,
+                            "logprob": token_info.logprob,
+                        }
+                        if token_info.top_logprobs:
+                            token_data["top_logprobs"] = [
+                                {"token": t.token, "logprob": t.logprob}
+                                for t in token_info.top_logprobs
+                            ]
+                        out_logprobs.append(token_data)
+                else:
+                    logger.warning(
+                        "OpenAI backend at base_url=%r returned no logprobs despite logprobs=true; "
+                        "downstream calibration will degrade. Verify the server supports logprobs.",
+                        base_url,
+                    )
             return TextResult(
                 text=str(out_text), response_id=getattr(resp, "id", None), logprobs=out_logprobs
             )

--- a/src/berry/hallucination_detector/backends/openai_backend.py
+++ b/src/berry/hallucination_detector/backends/openai_backend.py
@@ -21,11 +21,7 @@ def _is_local_base_url(base_url: Optional[str]) -> bool:
     if not base_url:
         return False
     lowered = base_url.lower()
-    return (
-        "127.0.0.1" in lowered
-        or "localhost" in lowered
-        or "0.0.0.0" in lowered
-    )
+    return "127.0.0.1" in lowered or "localhost" in lowered or "0.0.0.0" in lowered
 
 
 def _get_client(

--- a/src/berry/hallucination_detector/backends/openai_backend.py
+++ b/src/berry/hallucination_detector/backends/openai_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
@@ -13,6 +14,18 @@ except Exception:
 
 
 _thread_local = threading.local()
+logger = logging.getLogger(__name__)
+
+
+def _is_local_base_url(base_url: Optional[str]) -> bool:
+    if not base_url:
+        return False
+    lowered = base_url.lower()
+    return (
+        "127.0.0.1" in lowered
+        or "localhost" in lowered
+        or "0.0.0.0" in lowered
+    )
 
 
 def _get_client(
@@ -31,6 +44,9 @@ def _get_client(
 
     if not api_key:
         raise ValueError("OPENAI_API_KEY is not set (required for OpenAI backend)")
+
+    if _is_local_base_url(base_url) and (timeout_s is None or float(timeout_s) < 60.0):
+        timeout_s = 60.0
 
     key = (timeout_s, base_url, api_key)
     cache = getattr(_thread_local, "clients", None)
@@ -123,6 +139,12 @@ def call_text_chat(
                         ]
                     out_logprobs.append(token_data)
 
+            if include_logprobs and out_logprobs is None:
+                logger.warning(
+                    "OpenAI backend at base_url=%r returned no logprobs despite logprobs=true; "
+                    "downstream calibration will degrade. Verify the server supports logprobs.",
+                    base_url,
+                )
             return TextResult(
                 text=str(out_text), response_id=getattr(resp, "id", None), logprobs=out_logprobs
             )

--- a/src/berry/hallucination_detector/core.py
+++ b/src/berry/hallucination_detector/core.py
@@ -78,9 +78,6 @@ def _normalize_spans(spans: List[Dict[str, str]]) -> List[Span]:
     skipped: List[str] = []
     raw = spans or []
     for i, s in enumerate(raw):
-        if not isinstance(s, dict):
-            skipped.append(f"index {i}: not a dict (got {type(s).__name__})")
-            continue
         sid = str(s.get("sid", "") or "").strip()
         text = ""
         for k in _SPAN_TEXT_FALLBACK_KEYS:

--- a/src/berry/hallucination_detector/core.py
+++ b/src/berry/hallucination_detector/core.py
@@ -14,6 +14,30 @@ _DEFAULT_CITE_RE = re.compile(r"\[(?P<id>[A-Za-z]\w*|\d+)\]")
 
 _LN2 = math.log(2.0)
 
+_NO_LOGPROBS_MARKERS = (
+    "logprobs is None",
+    "empty logprobs list",
+    "missing logprob for generated token",
+)
+
+
+def _no_logprobs_verdict() -> Dict[str, Any]:
+    return {
+        "flagged": True,
+        "under_budget": True,
+        "error": (
+            "Backend did not return logprobs - Berry requires top_logprobs "
+            "support. Check backend."
+        ),
+        "error_type": "no_logprobs_from_backend",
+        "details": [],
+    }
+
+
+def _is_no_logprobs_error(exc: BaseException) -> bool:
+    msg = str(exc) or ""
+    return any(marker in msg for marker in _NO_LOGPROBS_MARKERS)
+
 
 @dataclass
 class Span:
@@ -39,13 +63,44 @@ def _to_bits(nats: float) -> float:
     return float(nats) / _LN2
 
 
+_SPAN_TEXT_FALLBACK_KEYS = ("text", "snippet", "content", "body", "passage")
+
+
 def _normalize_spans(spans: List[Dict[str, str]]) -> List[Span]:
+    """Coerce loose MCP span dicts into Span objects.
+
+    - Auto-assigns ``sid`` as ``s{i+1}`` when caller omitted it (1-indexed).
+    - Accepts text under fallback keys: text, snippet, content, body, passage.
+    - Silently skips entries with no usable text; raises ``ValueError`` with a
+      concrete diagnostic if a non-empty input list yields zero valid spans
+      (so the caller can distinguish malformed input from empty input).
+    """
     out: List[Span] = []
-    for s in spans or []:
-        sid = str(s.get("sid", "")).strip()
-        text = str(s.get("text", "")).strip()
-        if sid and text:
-            out.append(Span(sid=sid, text=text))
+    skipped: List[str] = []
+    raw = spans or []
+    for i, s in enumerate(raw):
+        if not isinstance(s, dict):
+            skipped.append(f"index {i}: not a dict (got {type(s).__name__})")
+            continue
+        sid = str(s.get("sid", "") or "").strip()
+        text = ""
+        for k in _SPAN_TEXT_FALLBACK_KEYS:
+            v = s.get(k)
+            if v is None:
+                continue
+            cand = str(v).strip()
+            if cand:
+                text = cand
+                break
+        if not text:
+            present = sorted(k for k in s.keys() if k != "sid")
+            skipped.append(f"index {i}: no usable text (keys present: {present or 'none'}; expected one of {list(_SPAN_TEXT_FALLBACK_KEYS)})")
+            continue
+        if not sid:
+            sid = f"s{i+1}"
+        out.append(Span(sid=sid, text=text))
+    if raw and not out:
+        raise ValueError("All spans malformed: " + "; ".join(skipped))
     return out
 
 
@@ -197,12 +252,22 @@ def run_detect_hallucination(
     pool_json_path: Optional[str] = None,
     local_llm_model_path: Optional[str] = None,
 ) -> Dict[str, Any]:
-    span_objs = _normalize_spans(spans)
+    try:
+        span_objs = _normalize_spans(spans)
+    except ValueError as e:
+        return {
+            "flagged": True,
+            "under_budget": True,
+            "error": str(e),
+            "error_type": "malformed_spans",
+            "details": [],
+        }
     if not span_objs:
         return {
             "flagged": True,
             "under_budget": True,
             "error": "No spans provided (cannot verify citations).",
+            "error_type": "no_spans",
             "details": [],
         }
 
@@ -238,17 +303,22 @@ def run_detect_hallucination(
     cfg = BackendConfig(
         kind=backend_kind, max_concurrency=int(max_concurrency), timeout_s=timeout_s
     )
-    results = score_trace_budget(
-        trace=trace,
-        verifier_model=verifier_model,
-        backend_cfg=cfg,
-        default_target=float(default_target),
-        temperature=float(temperature),
-        top_logprobs=int(top_logprobs),
-        placeholder=str(placeholder),
-        context_mode=str(context_mode),
-        reasoning=None,
-    )
+    try:
+        results = score_trace_budget(
+            trace=trace,
+            verifier_model=verifier_model,
+            backend_cfg=cfg,
+            default_target=float(default_target),
+            temperature=float(temperature),
+            top_logprobs=int(top_logprobs),
+            placeholder=str(placeholder),
+            context_mode=str(context_mode),
+            reasoning=None,
+        )
+    except ValueError as e:
+        if _is_no_logprobs_error(e):
+            return _no_logprobs_verdict()
+        raise
 
     details = [_format_result(r, units) for r in results]
 
@@ -331,17 +401,22 @@ def run_audit_trace_budget(
     cfg = BackendConfig(
         kind=backend_kind, max_concurrency=int(max_concurrency), timeout_s=timeout_s
     )
-    results = score_trace_budget(
-        trace=trace,
-        verifier_model=verifier_model,
-        backend_cfg=cfg,
-        default_target=float(default_target),
-        temperature=float(temperature),
-        top_logprobs=int(top_logprobs),
-        placeholder=str(placeholder),
-        context_mode=str(context_mode),
-        reasoning=None,
-    )
+    try:
+        results = score_trace_budget(
+            trace=trace,
+            verifier_model=verifier_model,
+            backend_cfg=cfg,
+            default_target=float(default_target),
+            temperature=float(temperature),
+            top_logprobs=int(top_logprobs),
+            placeholder=str(placeholder),
+            context_mode=str(context_mode),
+            reasoning=None,
+        )
+    except ValueError as e:
+        if _is_no_logprobs_error(e):
+            return _no_logprobs_verdict()
+        raise
 
     out = []
     for r in results:

--- a/src/berry/hallucination_detector/core.py
+++ b/src/berry/hallucination_detector/core.py
@@ -26,8 +26,7 @@ def _no_logprobs_verdict() -> Dict[str, Any]:
         "flagged": True,
         "under_budget": True,
         "error": (
-            "Backend did not return logprobs - Berry requires top_logprobs "
-            "support. Check backend."
+            "Backend did not return logprobs - Berry requires top_logprobs support. Check backend."
         ),
         "error_type": "no_logprobs_from_backend",
         "details": [],
@@ -94,10 +93,12 @@ def _normalize_spans(spans: List[Dict[str, str]]) -> List[Span]:
                 break
         if not text:
             present = sorted(k for k in s.keys() if k != "sid")
-            skipped.append(f"index {i}: no usable text (keys present: {present or 'none'}; expected one of {list(_SPAN_TEXT_FALLBACK_KEYS)})")
+            skipped.append(
+                f"index {i}: no usable text (keys present: {present or 'none'}; expected one of {list(_SPAN_TEXT_FALLBACK_KEYS)})"
+            )
             continue
         if not sid:
-            sid = f"s{i+1}"
+            sid = f"s{i + 1}"
         out.append(Span(sid=sid, text=text))
     if raw and not out:
         raise ValueError("All spans malformed: " + "; ".join(skipped))

--- a/src/berry/mcp_server.py
+++ b/src/berry/mcp_server.py
@@ -32,7 +32,16 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NotRequired, Optional, Tuple, TypedDict
+
+
+class SpanInput(TypedDict):
+    sid: str
+    text: str
+    snippet: NotRequired[str]
+    url: NotRequired[str]
+    title: NotRequired[str]
+
 
 from .config import load_config
 from .enforcement import AttemptRecord, EnforcementError, RunState, RunStore, SpanRecord
@@ -646,7 +655,7 @@ def create_server(
     @mcp.tool()
     def detect_hallucination(
         answer: str,
-        spans: List[Dict[str, str]],
+        spans: List[SpanInput],
         verifier_model: Optional[str] = None,
         default_target: float = 0.95,
         max_claims: int = 25,
@@ -654,7 +663,10 @@ def create_server(
         context_mode: str = "cited",
         timeout_s: float = 60.0,
     ) -> Dict[str, Any]:
-        """Information-budget diagnostic per claim."""
+        """Information-budget diagnostic per claim.
+
+        spans must each have ``sid`` (string id) and ``text`` (citation content).
+        """
         with _redirect_stdout_to_stderr():
             try:
                 return run_detect_hallucination(
@@ -667,13 +679,15 @@ def create_server(
                     context_mode=str(context_mode or "cited"),
                     timeout_s=float(timeout_s or 60.0),
                 )
+            except ValueError as e:
+                return {"flagged": True, "under_budget": True, "error": str(e), "error_type": "malformed_input", "details": []}
             except Exception as e:
-                return {"flagged": True, "under_budget": True, "error": str(e), "details": []}
+                return {"flagged": True, "under_budget": True, "error": str(e), "error_type": "internal", "details": []}
 
     @mcp.tool()
     def audit_trace_budget(
         steps: List[Dict[str, Any]],
-        spans: List[Dict[str, str]],
+        spans: List[SpanInput],
         verifier_model: Optional[str] = None,
         default_target: float = 0.95,
         require_citations: bool = False,
@@ -692,8 +706,10 @@ def create_server(
                     context_mode=str(context_mode or "cited"),
                     timeout_s=float(timeout_s or 60.0),
                 )
+            except ValueError as e:
+                return {"flagged": True, "under_budget": True, "error": str(e), "error_type": "malformed_input", "details": []}
             except Exception as e:
-                return {"flagged": True, "under_budget": True, "error": str(e), "details": []}
+                return {"flagged": True, "under_budget": True, "error": str(e), "error_type": "internal", "details": []}
 
     return mcp
 

--- a/src/berry/mcp_server.py
+++ b/src/berry/mcp_server.py
@@ -681,9 +681,21 @@ def create_server(
                     timeout_s=float(timeout_s or 60.0),
                 )
             except ValueError as e:
-                return {"flagged": True, "under_budget": True, "error": str(e), "error_type": "malformed_input", "details": []}
+                return {
+                    "flagged": True,
+                    "under_budget": True,
+                    "error": str(e),
+                    "error_type": "malformed_input",
+                    "details": [],
+                }
             except Exception as e:
-                return {"flagged": True, "under_budget": True, "error": str(e), "error_type": "internal", "details": []}
+                return {
+                    "flagged": True,
+                    "under_budget": True,
+                    "error": str(e),
+                    "error_type": "internal",
+                    "details": [],
+                }
 
     @mcp.tool()
     def audit_trace_budget(
@@ -708,9 +720,21 @@ def create_server(
                     timeout_s=float(timeout_s or 60.0),
                 )
             except ValueError as e:
-                return {"flagged": True, "under_budget": True, "error": str(e), "error_type": "malformed_input", "details": []}
+                return {
+                    "flagged": True,
+                    "under_budget": True,
+                    "error": str(e),
+                    "error_type": "malformed_input",
+                    "details": [],
+                }
             except Exception as e:
-                return {"flagged": True, "under_budget": True, "error": str(e), "error_type": "internal", "details": []}
+                return {
+                    "flagged": True,
+                    "under_budget": True,
+                    "error": str(e),
+                    "error_type": "internal",
+                    "details": [],
+                }
 
     return mcp
 

--- a/src/berry/mcp_server.py
+++ b/src/berry/mcp_server.py
@@ -32,16 +32,9 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List, NotRequired, Optional, Tuple, TypedDict
+from typing import Any, Dict, List, Optional, Tuple
 
-
-class SpanInput(TypedDict):
-    sid: str
-    text: str
-    snippet: NotRequired[str]
-    url: NotRequired[str]
-    title: NotRequired[str]
-
+from typing_extensions import NotRequired, TypedDict
 
 from .config import load_config
 from .enforcement import AttemptRecord, EnforcementError, RunState, RunStore, SpanRecord
@@ -53,6 +46,14 @@ from .mcp_env import load_mcp_env
 from .paths import ensure_berry_home, resolve_user_path
 from .permissions import can_read_path
 from .prompts import list_prompts
+
+
+class SpanInput(TypedDict):
+    sid: str
+    text: str
+    snippet: NotRequired[str]
+    url: NotRequired[str]
+    title: NotRequired[str]
 
 
 @contextlib.contextmanager

--- a/src/berry/mcp_server.py
+++ b/src/berry/mcp_server.py
@@ -32,7 +32,7 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -672,7 +672,7 @@ def create_server(
             try:
                 return run_detect_hallucination(
                     answer=str(answer or ""),
-                    spans=list(spans or []),
+                    spans=cast(List[Dict[str, str]], list(spans or [])),
                     verifier_model=str(verifier_model or _default_verifier_model()),
                     default_target=float(default_target or 0.95),
                     max_claims=int(max_claims or 25),
@@ -712,7 +712,7 @@ def create_server(
             try:
                 return run_audit_trace_budget(
                     steps=list(steps or []),
-                    spans=list(spans or []),
+                    spans=cast(List[Dict[str, str]], list(spans or [])),
                     verifier_model=str(verifier_model or _default_verifier_model()),
                     default_target=float(default_target or 0.95),
                     require_citations=bool(require_citations),

--- a/src/berry/recipes.py
+++ b/src/berry/recipes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 

--- a/src/berry/recipes.py
+++ b/src/berry/recipes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -13,6 +13,10 @@ class Recipe:
     description: str
     author: str
     prompts: List[str]
+    backend: Optional[str] = None
+    base_url: Optional[str] = None
+    model: Optional[str] = None
+    api_key: Optional[str] = None
 
 
 _BUILTIN: List[Recipe] = [
@@ -50,6 +54,36 @@ _BUILTIN: List[Recipe] = [
         description="Workflow prompt pack for optimizing any well-defined objective with baseline measurement, keep/revert decisions, and verified claims.",
         author="Berry",
         prompts=["objective_optimization_agent"],
+    ),
+    Recipe(
+        name="local_lmstudio",
+        title="Local backend: LM Studio",
+        description="Point Berry at a local LM Studio OpenAI-compatible server (default port 1234). Set OPENAI_API_KEY to any non-empty value.",
+        author="Berry",
+        prompts=["search_and_learn_verified"],
+        backend="local",
+        base_url="http://127.0.0.1:1234/v1",
+        model="gpt-oss-20b",
+    ),
+    Recipe(
+        name="local_llamacpp",
+        title="Local backend: llama.cpp server",
+        description="Point Berry at a local llama.cpp OpenAI-compatible server (default port 8080).",
+        author="Berry",
+        prompts=["search_and_learn_verified"],
+        backend="local",
+        base_url="http://127.0.0.1:8080/v1",
+        model="local",
+    ),
+    Recipe(
+        name="local_vllm",
+        title="Local backend: vLLM",
+        description="Point Berry at a local vLLM OpenAI-compatible server (default port 8000).",
+        author="Berry",
+        prompts=["search_and_learn_verified"],
+        backend="local",
+        base_url="http://127.0.0.1:8000/v1",
+        model="openai/gpt-oss-20b",
     ),
 ]
 
@@ -104,13 +138,20 @@ def _validate_recipe_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     prompts = payload.get("prompts")
     if not isinstance(prompts, list) or not all(isinstance(p, str) and p.strip() for p in prompts):
         raise ValueError("Recipe prompts must be a list of non-empty strings")
-    return {
+    out: Dict[str, Any] = {
         "name": name,
         "title": title,
         "description": description,
         "author": author,
         "prompts": prompts,
     }
+    for key in ("backend", "base_url", "model", "api_key"):
+        if key in payload and payload[key] is not None:
+            value = payload[key]
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"Recipe {key} must be a non-empty string when provided")
+            out[key] = value
+    return out
 
 
 def install_recipe_file_to_project(path: Path, *, project_root: Path, force: bool = False) -> Path:

--- a/tests/unit/test_local_backend.py
+++ b/tests/unit/test_local_backend.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from berry.hallucination_detector.backends import local_backend
+from berry.hallucination_detector.backends.local_backend import call_text_chat_local
+from berry.hallucination_detector.backends.openai_backend import TextResult
+
+
+def _mk_response(payload: Dict[str, Any]) -> MagicMock:
+    body = json.dumps(payload).encode("utf-8")
+    resp = MagicMock()
+    resp.read = MagicMock(return_value=body)
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _mk_chat_payload(
+    *,
+    text: str = "YES",
+    logprobs: Optional[Dict[str, Any]] = ...,  # type: ignore[assignment]
+    response_id: str = "chatcmpl-local-1",
+) -> Dict[str, Any]:
+    choice: Dict[str, Any] = {
+        "index": 0,
+        "message": {"role": "assistant", "content": text},
+        "finish_reason": "stop",
+    }
+    if logprobs is ...:
+        choice["logprobs"] = {
+            "content": [
+                {
+                    "token": "YES",
+                    "logprob": -0.1,
+                    "top_logprobs": [
+                        {"token": "YES", "logprob": -0.1},
+                        {"token": "NO", "logprob": -2.0},
+                        {"token": "UNSURE", "logprob": -3.0},
+                    ],
+                }
+            ]
+        }
+    else:
+        choice["logprobs"] = logprobs
+    return {
+        "id": response_id,
+        "object": "chat.completion",
+        "model": "local-model",
+        "choices": [choice],
+    }
+
+
+def _mk_http_error(code: int, reason: str = "Server Error") -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="http://test/chat/completions",
+        code=code,
+        msg=reason,
+        hdrs=None,  # type: ignore[arg-type]
+        fp=io.BytesIO(b""),
+    )
+
+
+def test_local_backend_url_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: List[str] = []
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        captured.append(req.full_url)
+        return _mk_response(_mk_chat_payload(logprobs=None))
+
+    monkeypatch.setenv("BERRY_LOCAL_BASE_URL", "http://from-env:1111/v1")
+    with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
+        call_text_chat_local(prompt="x", model="local-model", base_url="http://from-param:2222/v1", retries=0)
+    assert captured[-1].startswith("http://from-param:2222/v1")
+
+    with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
+        call_text_chat_local(prompt="x", model="local-model", retries=0)
+    assert captured[-1].startswith("http://from-env:1111/v1")
+
+    monkeypatch.delenv("BERRY_LOCAL_BASE_URL", raising=False)
+    with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
+        call_text_chat_local(prompt="x", model="local-model", retries=0)
+    default_url = captured[-1]
+    assert default_url.startswith("http://")
+    assert "127.0.0.1" in default_url or "localhost" in default_url
+
+
+def test_local_backend_request_shape() -> None:
+    captured: Dict[str, Any] = {}
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        raw = req.data
+        captured["body"] = json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+        return _mk_response(_mk_chat_payload())
+
+    with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
+        call_text_chat_local(
+            prompt="What is 2+2?",
+            model="qwen2.5-coder",
+            instructions="You are a calculator.",
+            temperature=0.0,
+            max_output_tokens=64,
+            include_logprobs=True,
+            top_logprobs=5,
+            base_url="http://localhost:1234/v1",
+            retries=0,
+        )
+
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/chat/completions")
+    header_names = {k.lower() for k in captured["headers"]}
+    assert "content-type" in header_names
+    body = captured["body"]
+    assert body["model"] == "qwen2.5-coder"
+    assert isinstance(body["messages"], list) and len(body["messages"]) == 2
+    assert body["messages"][0] == {"role": "system", "content": "You are a calculator."}
+    assert body["messages"][1] == {"role": "user", "content": "What is 2+2?"}
+    assert body["temperature"] == 0.0
+    assert "max_tokens" in body and int(body["max_tokens"]) >= 16
+    assert body["logprobs"] is True
+    assert body["top_logprobs"] == 5
+
+
+def test_local_backend_parses_logprobs() -> None:
+    payload = _mk_chat_payload(text="YES")
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        return _mk_response(payload)
+
+    with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
+        res = call_text_chat_local(
+            prompt="YES",
+            model="local-model",
+            include_logprobs=True,
+            top_logprobs=3,
+            base_url="http://localhost:1234/v1",
+            retries=0,
+        )
+
+    assert isinstance(res, TextResult)
+    assert res.text == "YES"
+    assert res.response_id == "chatcmpl-local-1"
+    assert res.logprobs is not None
+    first = res.logprobs[0]
+    assert first["token"] == "YES"
+    assert first["logprob"] == -0.1
+    assert isinstance(first["top_logprobs"], list)
+
+
+def test_local_backend_handles_null_logprobs() -> None:
+    payload = _mk_chat_payload(text="hello", logprobs=None)
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        return _mk_response(payload)
+
+    with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
+        res = call_text_chat_local(
+            prompt="hi",
+            model="local-model",
+            include_logprobs=True,
+            top_logprobs=3,
+            base_url="http://localhost:1234/v1",
+            retries=0,
+        )
+
+    assert isinstance(res, TextResult)
+    assert res.text == "hello"
+    assert res.logprobs is None
+
+
+def test_local_backend_retries_on_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(local_backend.time, "sleep", lambda _s: None)
+    calls: List[int] = []
+    ok_payload = _mk_chat_payload(text="recovered", logprobs=None)
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        calls.append(1)
+        if len(calls) == 1:
+            raise _mk_http_error(503, "Service Unavailable")
+        return _mk_response(ok_payload)
+
+    with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
+        res = call_text_chat_local(
+            prompt="x",
+            model="local-model",
+            base_url="http://localhost:1234/v1",
+            retries=3,
+            retry_backoff_s=0.0,
+        )
+
+    assert len(calls) == 2
+    assert res.text == "recovered"
+
+
+def test_local_backend_raises_after_retries_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(local_backend.time, "sleep", lambda _s: None)
+    calls: List[int] = []
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        calls.append(1)
+        raise _mk_http_error(503, "Service Unavailable")
+
+    with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
+        with pytest.raises(RuntimeError):
+            call_text_chat_local(
+                prompt="x",
+                model="local-model",
+                base_url="http://localhost:1234/v1",
+                retries=2,
+                retry_backoff_s=0.0,
+            )
+
+    assert len(calls) == 3

--- a/tests/unit/test_local_backend.py
+++ b/tests/unit/test_local_backend.py
@@ -76,7 +76,9 @@ def test_local_backend_url_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setenv("BERRY_LOCAL_BASE_URL", "http://from-env:1111/v1")
     with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):
-        call_text_chat_local(prompt="x", model="local-model", base_url="http://from-param:2222/v1", retries=0)
+        call_text_chat_local(
+            prompt="x", model="local-model", base_url="http://from-param:2222/v1", retries=0
+        )
     assert captured[-1].startswith("http://from-param:2222/v1")
 
     with patch.object(local_backend.urllib.request, "urlopen", side_effect=fake_urlopen):

--- a/tests/unit/test_span_normalization.py
+++ b/tests/unit/test_span_normalization.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 """Tests for _normalize_spans auto-sid + loud-failure behavior."""
+from __future__ import annotations
 
 import pytest
 

--- a/tests/unit/test_span_normalization.py
+++ b/tests/unit/test_span_normalization.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""Tests for _normalize_spans auto-sid + loud-failure behavior."""
+
+import pytest
+
+from berry.hallucination_detector.core import (
+    Span,
+    _normalize_spans,
+    run_detect_hallucination,
+)
+
+
+def test_normalize_spans_empty_list_returns_empty() -> None:
+    assert _normalize_spans([]) == []
+
+
+def test_normalize_spans_none_returns_empty() -> None:
+    assert _normalize_spans(None) == []  # type: ignore[arg-type]
+
+
+def test_normalize_spans_explicit_sid_and_text_preserved() -> None:
+    spans = _normalize_spans([{"sid": "s1", "text": "x"}])
+    assert len(spans) == 1
+    assert isinstance(spans[0], Span)
+    assert spans[0].sid == "s1"
+    assert spans[0].text == "x"
+
+
+def test_normalize_spans_auto_assigns_sid_when_missing() -> None:
+    spans = _normalize_spans([{"text": "x"}])
+    assert len(spans) == 1
+    assert spans[0].sid == "s1"
+    assert spans[0].text == "x"
+
+
+def test_normalize_spans_auto_sid_is_sequential() -> None:
+    spans = _normalize_spans(
+        [
+            {"text": "alpha"},
+            {"text": "beta"},
+            {"text": "gamma"},
+        ]
+    )
+    assert [s.sid for s in spans] == ["s1", "s2", "s3"]
+    assert [s.text for s in spans] == ["alpha", "beta", "gamma"]
+
+
+def test_normalize_spans_snippet_fallback() -> None:
+    spans = _normalize_spans([{"snippet": "x"}])
+    assert len(spans) == 1
+    assert spans[0].sid == "s1"
+    assert spans[0].text == "x"
+
+
+def test_normalize_spans_text_wins_over_snippet() -> None:
+    spans = _normalize_spans([{"text": "real", "snippet": "ignored"}])
+    assert len(spans) == 1
+    assert spans[0].text == "real"
+
+
+def test_normalize_spans_empty_span_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        _normalize_spans([{}])
+
+
+def test_normalize_spans_whitespace_only_text_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        _normalize_spans([{"text": "   "}])
+
+
+def _use_dummy_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERRY_VERIFIER_BACKEND", "dummy")
+
+
+def test_run_detect_hallucination_no_spans_returns_error_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_dummy_backend(monkeypatch)
+    result = run_detect_hallucination(answer="Foo.", spans=[])
+    assert isinstance(result, dict)
+    assert result.get("error_type") == "no_spans"
+    assert result.get("flagged") is True
+    assert result.get("under_budget") is True
+    assert "error" in result
+    assert result.get("details") == []
+
+
+def test_run_detect_hallucination_malformed_spans_returns_error_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _use_dummy_backend(monkeypatch)
+    result = run_detect_hallucination(answer="Foo.", spans=[{}])
+    assert isinstance(result, dict)
+    assert result.get("error_type") == "malformed_spans"
+    assert result.get("flagged") is True
+    assert result.get("under_budget") is True
+    assert result.get("details") == []

--- a/tests/unit/test_span_normalization.py
+++ b/tests/unit/test_span_normalization.py
@@ -1,4 +1,5 @@
 """Tests for _normalize_spans auto-sid + loud-failure behavior."""
+
 from __future__ import annotations
 
 import pytest


### PR DESCRIPTION
## Summary

This PR fixes a longstanding silent UX failure in `detect_hallucination` / `audit_trace_budget` and adds a first-class local-model verifier backend (LM Studio / llama.cpp / vLLM).

## Bug fix — span-normalization silent failure

The MCP tools declared `spans: List[Dict[str, str]]`, which propagates as `{"items": {"type": "object", "additionalProperties": {"type": "string"}}}` in the exposed JSON schema. Callers see "array of objects of strings" with no required keys. Internally, `core._normalize_spans` requires **both** `sid` and `text` and silently filters anything else. The combination meant:

- Caller sends `[{"text": "..."}]` (no sid) → filtered → `{flagged: true, error: "No spans provided"}`
- Caller sends `[{"url":..., "title":..., "snippet":...}]` (RAG shape) → filtered → same
- Caller sends `[{}]` → filtered → same

…and that return value is **indistinguishable** from a real hallucination flag, so every MCP client (including Claude Code) silently misreads input errors as detections. Repro:

```jsonc
// call
{ "answer": "Paris is the capital of France.", "spans": [{ "text": "Paris is the capital of France." }] }
// previous response
{ "result": { "flagged": true, "under_budget": true, "error": "No spans provided (cannot verify citations).", "details": [] } }
```

### Fix

1. **Tighten MCP schema** (`mcp_server.py`): `spans: List[SpanInput]` where `SpanInput` is a `TypedDict` with required `sid: str`, `text: str` and `NotRequired[str]` for `snippet`/`url`/`title`. pydantic now rejects malformed input at the protocol layer with a concrete `Field required` error.
2. **Distinct `error_type`** on every error return: `no_spans`, `malformed_spans`, `malformed_input`, `internal`, `no_logprobs_from_backend`. Clients can finally tell input errors from real flags.
3. **Lenient lib-level fallback** (`core._normalize_spans`): for direct Python callers, auto-assign `sid = s{i+1}` when missing and accept text under fallback keys `snippet / content / body / passage`; raise `ValueError` with a per-index diagnostic when all spans malformed.
4. **Graceful logprob fallback**: when the verifier backend returns null/empty logprobs (common with under-spec local OpenAI-compat servers), return `{error_type: "no_logprobs_from_backend"}` instead of crashing in `stage_ab`.

## Feature — local-model verifier backend

`openai_backend` already honors `base_url` overrides, but it goes through the `openai` SDK (header coercion, base_url precedence quirks, mandatory SDK install). This PR adds a sibling backend that:

- Talks directly to `/v1/chat/completions` via `urllib` (pure stdlib, no SDK dep).
- Resolves base URL by param > env (`BERRY_LOCAL_BASE_URL`) > default `http://127.0.0.1:1234/v1` (LM Studio).
- Returns the same `TextResult` shape as `openai_backend` — drop-in for downstream scoring.
- Handles missing `top_logprobs` gracefully (sets `logprobs=None`, lets the core guard short-circuit with a clean error).

Wiring:

- `BerryConfig.verifier_backend / verifier_model / local_base_url` + env overrides (`BERRY_VERIFIER_BACKEND`, `BERRY_VERIFIER_MODEL`, `BERRY_LOCAL_BASE_URL`).
- `make_backend("local") → LocalBackend` in `backends/base.py`.
- 3 new recipes: `local_lmstudio`, `local_llamacpp`, `local_vllm`.

## UX

- `openai_backend`: warn-log when `include_logprobs=True` but the server returns null logprobs (so calibration regressions are visible instead of silent); bump `timeout_s` floor to 60s when `base_url` is loopback to cover local cold-starts.
- `berry doctor`: rewritten as a real backend probe — issues a logprobs-enabled chat call, reports `backend / model / base_url / http_status / latency_ms / logprobs_populated / top_logprobs_nonempty`, and exits non-zero if logprobs aren't returned.

## Tooling

- `scripts/calibrate_local.py`: 20 supported + 20 unsupported claim pairs, prints P(YES) histograms per class and suggests an optimal `verification_*_default_target` value for `~/.berry/config.json`.
- `docs/LOCAL-MODELS.md`: runtime compatibility matrix (LM Studio, vLLM, llama.cpp, MLX-LM, Ollama, sglang, text-generation-webui), setup steps per runtime, calibration guide, troubleshooting.
- README "Local Models" section + doc index entry.

## Test plan

- [x] `tests/unit/test_span_normalization.py` — 11 cases: empty, explicit, auto-sid, sequential auto-sid, snippet fallback, text-wins, whitespace-only, `{}` → `ValueError`, `error_type="no_spans"`, `error_type="malformed_spans"`. All pass.
- [x] `tests/unit/test_local_backend.py` — 6 cases: URL resolution precedence, request shape, logprobs parsing, null-logprobs handling, retry on `urllib.error.HTTPError(503)`, retries-exhausted → `RuntimeError`. All pass.
- [x] Full test suite: 17/17 new tests pass; existing tests unaffected by the change set.
- [x] Live MCP smoke test against a running Berry server confirms pydantic now rejects malformed spans with `Field required: spans.0.sid` instead of returning the misleading `{flagged: true, ...}`; well-formed spans return `P(YES) ≈ 0.9999993` as expected.

## Notes for reviewers

- Schema tightening at the MCP layer may break clients that were relying on the loose shape. The lib-level `_normalize_spans` still auto-pads `sid`, so direct Python callers retain the lenient behavior. If you'd prefer the MCP layer to also auto-pad, the `SpanInput` TypedDict can be relaxed to `sid: NotRequired[str]`; I left it strict because callers passing nothing meaningful (`{}`) should get a clear protocol error rather than a silently-flagged "hallucination."
- `local_backend.py` is intentionally stdlib-only so it can be imported without pulling the `openai` SDK into the dep graph for users who only want local inference.