### PR TITLE
SQLite run ledger, claim/evidence graph, span management v2, and assistant installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Berry runs a local MCP server with a safe, repo‑scoped toolpack plus verificat
 Berry ships a single MCP surface: **classic**.
 
 Classic includes:
-- Verification tools (`detect_hallucination`, `audit_trace_budget`)
-- Run & evidence notebook tools (start/load runs, add/list/search spans)
+- Verification tools (`detect_hallucination`, `audit_trace_budget`) plus run-scoped variants that resolve evidence from the server-owned span ledger
+- Run & evidence notebook tools (start/load runs, add/list/query/extract/pack spans)
+- A claim/evidence graph (`create_claim`, `link_claim_evidence`, `audit_claims`, `list_audits`) persisted in a SQLite ledger
 
-See `docs/MCP.md` and `docs/workflows/README.md`.
+See `docs/MCP.md`, `docs/SPANS.md`, and `docs/workflows/README.md`.
 
 Berry integrates with Cursor, Codex, Claude Code, and Gemini CLI via config files committed to your repo.
 
@@ -80,6 +81,7 @@ berry setup
 - `docs/INSTALL.md` — multi-platform assistant installer
 - `docs/CONFIGURATION.md` — config files, defaults, and env vars
 - `docs/MCP.md` — tools/prompts and transport details
+- `docs/SPANS.md` — span-ledger model, SQLite/event-log persistence, claim/evidence graph, evidence-pack policy, and server-resolved verification
 - `docs/PACKAGING.md` — release pipeline (macOS pkg + Homebrew cask)
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ This provisions a hosted API key, writes MCP configs for Cursor/Codex/Claude Cod
 
 3) Reload MCP servers in your client.
 
+For a platform-aware assistant installer with user/profile installs, platform
+shortcuts, hooks, always-on instruction files, and embedded path refreshes, use:
+
+```bash
+berry install --platform codex
+berry cursor install
+berry install --project --platform gemini
+```
+
+See `docs/INSTALL.md` for the full platform table.
+
 To use your own API key or a different backend instead of the hosted key:
 
 ```bash
@@ -66,6 +77,7 @@ berry setup
 
 - `docs/USAGE.md` — task‑oriented guides
 - `docs/CLI.md` — command reference
+- `docs/INSTALL.md` — multi-platform assistant installer
 - `docs/CONFIGURATION.md` — config files, defaults, and env vars
 - `docs/MCP.md` — tools/prompts and transport details
 - `docs/PACKAGING.md` — release pipeline (macOS pkg + Homebrew cask)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Berry ships a single MCP surface: **classic**.
 Classic includes:
 - Verification tools (`detect_hallucination`, `audit_trace_budget`) plus run-scoped variants that resolve evidence from the server-owned span ledger
 - Run & evidence notebook tools (start/load runs, add/list/query/extract/pack spans)
-- A claim/evidence graph (`create_claim`, `link_claim_evidence`, `audit_claims`, `list_audits`) persisted in a SQLite ledger
+- A claim/evidence graph (`create_claim`, `link_claim_evidence`, `audit_claims`, `list_audits`) persisted in an incremental, tamper-evident SQLite ledger
 
 See `docs/MCP.md`, `docs/SPANS.md`, and `docs/workflows/README.md`.
 
@@ -81,7 +81,7 @@ berry setup
 - `docs/INSTALL.md` — multi-platform assistant installer
 - `docs/CONFIGURATION.md` — config files, defaults, and env vars
 - `docs/MCP.md` — tools/prompts and transport details
-- `docs/SPANS.md` — span-ledger model, SQLite/event-log persistence, claim/evidence graph, evidence-pack policy, and server-resolved verification
+- `docs/SPANS.md` — span-ledger model, incremental SQLite/event-log persistence, claim/evidence graph, evidence-pack policy, and server-resolved verification
 - `docs/PACKAGING.md` — release pipeline (macOS pkg + Homebrew cask)
 
 ## Tests

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -38,6 +38,41 @@ Safety note:
   If no `.git` is found, pass `--project-root` explicitly (or set `BERRY_ALLOW_NON_GIT_ROOT=1` to
   treat the current directory as the project scope).
 
+### `berry install`
+Install Berry into AI coding assistants using a platform-aware installer.
+
+```
+berry install [PLATFORM ...] [--platform PLATFORM] [--project] [--project-root PATH]
+              [--name berry] [--berry-command CMD] [--force] [--dry-run] [--json]
+              [--no-hooks] [--no-mcp] [--list-platforms]
+```
+
+Examples:
+
+```bash
+berry install                         # Claude Code, or Windows flavor on Windows
+berry install --platform codex
+berry install codex gemini cursor     # install multiple platforms
+berry codex install                   # platform shortcut
+berry cursor install --project
+berry install --platform gemini --dry-run --json
+```
+
+Supported platforms:
+
+`claude`, `windows`, `codebuddy`, `codex`, `opencode`, `kilo`, `copilot`,
+`vscode`, `aider`, `claw`, `droid`, `trae`, `trae-cn`, `gemini`, `hermes`,
+`kimi`, `amp`, `kiro`, `pi`, `cursor`, `devin`, `antigravity`.
+
+Notes:
+
+- Generated configs embed the resolved Berry command path. Re-run `berry install` after moving or upgrading Berry to refresh that path.
+- `--project` writes project-scoped artifacts where the platform supports them and requires a git repo unless `--project-root` or `BERRY_ALLOW_NON_GIT_ROOT=1` is supplied.
+- JSON config files are merged and fail closed on invalid JSON unless `--force` is passed.
+- `--no-hooks` skips hook registration. `--no-mcp` skips MCP config registration.
+
+See `docs/INSTALL.md` for the platform table and safety model.
+
 ### `berry doctor`
 Print health checks and basic environment info as JSON.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,76 @@
+# Berry assistant installer
+
+`berry install` registers Berry with AI coding assistants using a platform-aware installer.
+
+The installer writes three kinds of artifacts, depending on the platform:
+
+1. a Berry skill file (`SKILL.md`) where the host supports skills;
+2. an always-on instruction file or managed section (`AGENTS.md`, `CLAUDE.md`, `.cursor/rules/berry.mdc`, etc.);
+3. MCP client config and hooks where the host exposes a stable config surface.
+
+Generated artifacts embed the resolved Berry command path. Re-run `berry install` after reinstalling Berry, moving a `pipx`/`uv` environment, replacing a PyInstaller binary, or changing Python versions. The installer will idempotently refresh the embedded path without duplicating Berry sections.
+
+## Pick your platform
+
+| Platform | Install command |
+|---|---|
+| Claude Code (Linux/Mac) | `berry install` |
+| Claude Code (Windows) | `berry install` (auto-detected on Windows) or `berry install --platform windows` |
+| CodeBuddy | `berry install --platform codebuddy` |
+| Codex | `berry install --platform codex` |
+| OpenCode | `berry install --platform opencode` |
+| Kilo Code | `berry install --platform kilo` |
+| GitHub Copilot CLI | `berry install --platform copilot` |
+| VS Code Copilot Chat | `berry vscode install` |
+| Aider | `berry install --platform aider` |
+| OpenClaw | `berry install --platform claw` |
+| Factory Droid | `berry install --platform droid` |
+| Trae | `berry install --platform trae` |
+| Trae CN | `berry install --platform trae-cn` |
+| Gemini CLI | `berry install --platform gemini` |
+| Hermes | `berry install --platform hermes` |
+| Kimi Code | `berry install --platform kimi` |
+| Amp | `berry amp install` |
+| Kiro IDE/CLI | `berry kiro install` |
+| Pi coding agent | `berry install --platform pi` |
+| Cursor | `berry cursor install` |
+| Devin CLI | `berry devin install` |
+| Google Antigravity | `berry antigravity install` |
+
+Codex installs also ensure `multi_agent = true` under `[features]` in `~/.codex/config.toml` or `.codex/config.toml` for project-scoped installs. CodeBuddy uses Claude-style `PreToolUse` hooks where available. Trae and Trae CN use `AGENTS.md` as the always-on mechanism because hooks are not assumed. Aider and OpenClaw get sequential always-on guidance only. Factory Droid guidance mentions Task-style parallel dispatch where the host supports it.
+
+VS Code Copilot Chat installs use VS Code's native MCP shape: user-scope installs write the active VS Code user-profile `mcp.json`, and project-scope installs write `.vscode/mcp.json` with a top-level `servers` object.
+
+## Scope
+
+By default, `berry install` writes user-profile artifacts where the platform supports them. To install into the current repository instead, pass `--project`:
+
+```bash
+berry install --project --platform codex
+berry cursor install --project
+berry gemini install --project
+```
+
+Project installs require a git repository by default, matching `berry init` safety behavior. Pass `--project-root PATH` or set `BERRY_ALLOW_NON_GIT_ROOT=1` when intentionally installing into a non-git directory.
+
+## Useful flags
+
+```bash
+berry install --list-platforms
+berry install --platform codex --dry-run
+berry install --platform gemini --json
+berry install --platform claude --berry-command /opt/berry/bin/berry
+berry install --platform claude --no-hooks
+berry install --platform cursor --no-mcp
+berry install codex gemini cursor
+```
+
+`--berry-command` is primarily for package maintainers and tests. Normal users should let the installer resolve the current Berry executable automatically.
+
+## Safety model
+
+- Writes are idempotent: Berry-owned Markdown sections are bounded by `<!-- berry:install:start -->` and `<!-- berry:install:end -->`.
+- JSON writes preserve unrelated keys and fail closed on invalid JSON unless `--force` is provided.
+- Text writes use an atomic temporary-file replace.
+- `--dry-run` reports all planned actions without touching the filesystem.
+- Repeated installs replace old Berry hooks/sections rather than appending duplicates.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -21,6 +21,7 @@ Berry exposes a focused set of tools for evidence collection, attempt ledgers, a
 - `start_run(problem_statement, deliverable, run_id?)` — create a new run directory with a problem statement + immutable deliverable anchor.
 - `load_run(run_id)` — resume an existing run (loads from disk if necessary) and set it active.
 - `get_deliverable(run_id?)` — get the immutable deliverable anchor for the active run.
+- `export_run_ledger(run_id?)` — regenerate full JSON/TSV inspection exports from the authoritative SQLite ledger.
 
 #### Evidence spans
 
@@ -41,12 +42,9 @@ Berry exposes a focused set of tools for evidence collection, attempt ledgers, a
   - Supports claim/action basics plus optional `git_state`, `objective_metric`, `objective_value`, and `result_summary` fields.
 - `list_attempts(run_id?, limit?)` — list recorded attempts for the active run.
 
-Berry persists the run state in `~/.berry/runs/<run_id>/` and also writes machine-readable ledgers:
-- `run.sqlite` — SQLite source of truth with normalized runs/spans/attempts/claims/links/audits and a tamper-evident `ledger_events` table
-- `run.json` — schema-versioned compatibility export containing v3 state
-- `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl` — inspection exports
+Berry persists the authoritative run state in `~/.berry/runs/<run_id>/run.sqlite`. The SQLite ledger uses normalized runs/spans/attempts/claims/links/audits tables plus a tamper-evident `ledger_events` table. Hot writes are incremental: only changed rows are upserted, each row carries a payload hash, and each commit appends a hash-chained state event.
 
-SQLite writes use a transaction, WAL mode, foreign keys, payload hashes, and event-hash chain verification. Export writes are atomic and persistence failures fail closed with a visible error. Legacy JSON-only runs still load and migrate in memory.
+Full JSON/TSV inspection exports are no longer regenerated on every span append by default. Use `export_run_ledger(run_id?)` or set `BERRY_LEDGER_EXPORT_MODE=sync` to write `run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, and `ledger_events.jsonl` for legacy consumers. `BERRY_LEDGER_EXPORT_MODE=hot` writes lightweight head / append-only mirrors on each commit; the default is `off`. Legacy JSON-only runs still load and migrate into SQLite.
 
 See `docs/SPANS.md` for the full span schema, evidence-pack policy, and trust model.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -24,12 +24,16 @@ Berry exposes a focused set of tools for evidence collection, attempt ledgers, a
 
 #### Evidence spans
 
-- `add_span(text, source?, run_id?, meta?)` — add evidence from text.
-- `add_file_span(path, start_line, end_line, source?, run_id?, meta?)` — capture lines from a local file (path + line range) as evidence.
-- `list_spans(run_id?, limit?)` — list all spans (metadata only).
-- `get_span(sid, run_id?)` — fetch full span text.
-- `search_spans(query, run_id?, limit?)` — search over span texts (lightweight token match scoring).
-- `distill_span(parent_sid, pattern, run_id?, source?, flags?, max_lines?)` — extract key lines from a large span (regex-based), creating a new span.
+- `add_span(text, source?, run_id?, meta?, kind?, source_type?, trust?, sensitivity?, tags?)` — add immutable text evidence to the run ledger.
+- `add_file_span(path, start_line, end_line, source?, run_id?, meta?, read_mode?, kind?, trust?, sensitivity?, tags?)` — capture lines from a local file as evidence with path, byte-offset, file-hash, git, and trust provenance. `read_mode` defaults to `baseline` and falls back to worktree with explicit provenance when no baseline object is available.
+- `list_spans(run_id?, limit?, kinds?, source_types?, trust?, status?)` — list span metadata, including `eid`, `kind`, `trust`, `status`, `sensitivity`, hashes, locator, parents, and tags.
+- `get_span(sid, run_id?, include_sensitive_text?)` — fetch a span. Sensitive text is redacted unless explicitly requested.
+- `mark_span(sid, run_id?, status?, sensitivity?, tags_add?, tags_remove?, trust?)` — update mutable annotations without mutating span text/provenance.
+- `search_spans(query, run_id?, limit?)` — compatibility lexical search over active non-derived spans.
+- `query_evidence(query, run_id?, limit?, kinds?, source_types?, trust?, status?, include_derived?, include_stale?)` — filterable evidence retrieval.
+- `extract_span(parent_sid, selector, run_id?, reason?, source?, max_lines?, tags?)` — create an offset-preserving derived span from a regex or line-range selector. No-match creates no evidence span.
+- `distill_span(parent_sid, pattern, run_id?, source?, flags?, max_lines?)` — compatibility wrapper around regex extraction.
+- `get_evidence_pack(sids, run_id?, max_chars?, allow_sensitive?, include_stale?, allow_untrusted?)` — resolve run-owned SIDs into the exact verifier-safe evidence pack.
 
 #### Attempt ledger
 
@@ -38,22 +42,45 @@ Berry exposes a focused set of tools for evidence collection, attempt ledgers, a
 - `list_attempts(run_id?, limit?)` — list recorded attempts for the active run.
 
 Berry persists the run state in `~/.berry/runs/<run_id>/` and also writes machine-readable ledgers:
-- `run.json`
-- `evidence.tsv`
-- `attempts.tsv`
+- `run.sqlite` — SQLite source of truth with normalized runs/spans/attempts/claims/links/audits and a tamper-evident `ledger_events` table
+- `run.json` — schema-versioned compatibility export containing v3 state
+- `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl` — inspection exports
+
+SQLite writes use a transaction, WAL mode, foreign keys, payload hashes, and event-hash chain verification. Export writes are atomic and persistence failures fail closed with a visible error. Legacy JSON-only runs still load and migrate in memory.
+
+See `docs/SPANS.md` for the full span schema, evidence-pack policy, and trust model.
+
+#### Claim/evidence graph
+
+- `create_claim(text, run_id?, kind?, target?, status?, source?, tags?, meta?)` — create a structured claim node.
+- `link_claim_evidence(cid, sid, run_id?, relation?, note?, audit_id?, meta?)` — attach a typed evidence edge. `supports` / `contradicts` require citable evidence spans; `background` may point at anchors.
+- `list_claim_evidence(run_id?, cid?, sid?, relation?)` — list graph edges by claim, span, or relation.
+- `list_claims(run_id?, limit?, status?, kinds?, include_evidence?)` — list claims and their evidence edges.
+- `get_claim(cid, run_id?, include_evidence?, include_audits?)` — fetch one claim with graph context.
+- `mark_claim(cid, run_id?, status?, kind?, target?, latest_audit_id?, tags_add?, tags_remove?, meta_update?, reason?)` — update mutable claim annotations without changing claim text.
+- `audit_claims(claim_ids?, run_id?, evidence_relations?, verifier_model?, context_mode?, include_prompts?, max_prompt_chars?, top_logprobs?, min_log_odds_gain?, use_cache?, group_claims?, max_group_size?, max_group_prompt_chars?, timeout_s?, max_evidence_chars?, allow_sensitive?, include_stale?, allow_untrusted?, max_claims?, record_audit?)` — build verifier steps from graph-linked claims and evidence, then update claim statuses and audit-linked edges.
+- `list_audits(run_id?, claim_id?, limit?)` — list verifier audit records.
+
+`audit_claims` uses claim targets as verifier confidence thresholds, resolves all cited spans server-side, records a non-citable audit span, records an `AuditRecord`, and updates each audited claim to `supported`, `contradicted`, or `insufficient` according to the verifier detail status.
 
 #### Verification
 
-- `detect_hallucination(answer, spans, verifier_model?, default_target?, max_claims?, claim_split?, require_citations?, context_mode?, include_prompts?, max_prompt_chars?, top_logprobs?, min_log_odds_gain?, use_cache?, group_claims?, max_group_size?, max_group_prompt_chars?)` — information-budget diagnostic per claim.
-  - `require_citations=true` will flag claims that have no citations even if they could be supported by the overall context.
-  - `context_mode="cited"` is the default and verifies each claim only against its cited spans.
-  - `group_claims=true` is the default. Claims with the same verifier context are scored in one multi-claim prompt using one Y/N/U answer line per claim. If the grouped output cannot be parsed into exactly one answer distribution per claim, Berry automatically retries that group with legacy single-claim prompts.
-  - `max_group_size` defaults to `8`; `max_group_prompt_chars` defaults to `24000` and causes oversized chunks to split or fall back to single prompts.
-  - `include_prompts=true` returns the exact verifier prompt used. For grouped claims, this is the grouped prompt shared by the claims in that verifier call.
-- `audit_trace_budget(steps, spans, verifier_model?, default_target?, require_citations?, context_mode?, include_prompts?, max_prompt_chars?, top_logprobs?, min_log_odds_gain?, use_cache?, group_claims?, max_group_size?, max_group_prompt_chars?)` — score explicit (claim, cites) steps.
-  - The verifier is target-directed: cited context must push the posterior YES probability to `default_target`, and redacted context must not already support the claim.
-  - Deterministic preflight statuses such as `missing_citations`, `unknown_citations`, `empty_context`, and `no_spans` are returned without calling the verifier.
-  - Responses include both logical `verifier_calls` and estimated physical `verifier_api_calls_planned`; the latter reflects grouped prompt fanout and grouped-fallback retries.
+Prefer the run-scoped tools:
+
+- `detect_hallucination_run(answer, run_id?, sid_whitelist?, verifier_model?, default_target?, max_claims?, claim_split?, require_citations?, context_mode?, include_prompts?, max_prompt_chars?, top_logprobs?, min_log_odds_gain?, use_cache?, group_claims?, max_group_size?, max_group_prompt_chars?, timeout_s?, max_evidence_chars?, allow_sensitive?, include_stale?, allow_untrusted?, record_audit?, record_claim_graph?)` — detect answer hallucinations by resolving `[S#]` citations from the server-owned run ledger.
+- `audit_trace_budget_run(steps, run_id?, sid_whitelist?, verifier_model?, default_target?, require_citations?, context_mode?, include_prompts?, max_prompt_chars?, top_logprobs?, min_log_odds_gain?, use_cache?, group_claims?, max_group_size?, max_group_prompt_chars?, timeout_s?, max_evidence_chars?, allow_sensitive?, include_stale?, allow_untrusted?, record_audit?, record_claim_graph?, auto_create_claims?)` — audit explicit `(claim, cites)` steps using server-resolved evidence. Steps may include `claim_id` / `cid`; when present, Berry updates the corresponding claim graph node. `auto_create_claims=true` creates claim nodes for anonymous steps.
+
+The run-scoped tools fail closed when citations reference unknown, stale, sensitive, non-citable, or over-budget spans. Reports include an `evidence_pack` summary containing `pack_id`, `text_sha256`, input SIDs, materialized SIDs, exclusions, truncation state, and policy. When `record_audit=true`, Berry records a non-citable `kind=audit` span summarizing the verifier call.
+
+They use the hardened v2 verifier underneath: `context_mode="cited"` by default, target-directed posterior checks, prior-leak detection, deterministic preflight statuses, verifier caching, and grouped multi-claim prompts with safe fallback to single-claim prompts.
+
+Legacy raw-span tools remain available for compatibility:
+
+- `detect_hallucination(answer, spans, verifier_model?, default_target?, max_claims?, claim_split?, require_citations?, context_mode?, include_prompts?, max_prompt_chars?, top_logprobs?, min_log_odds_gain?, use_cache?, group_claims?, max_group_size?, max_group_prompt_chars?)` — information-budget diagnostic per claim using caller-supplied span text.
+- `audit_trace_budget(steps, spans, verifier_model?, default_target?, require_citations?, context_mode?, include_prompts?, max_prompt_chars?, top_logprobs?, min_log_odds_gain?, use_cache?, group_claims?, max_group_size?, max_group_prompt_chars?)` — score explicit `(claim, cites)` steps using caller-supplied span text.
+
+The legacy tools are lower-trust because the caller supplies the evidence text. New workflows should use the `_run` variants.
+
 
 ### Prompts (workflows)
 

--- a/docs/SPANS.md
+++ b/docs/SPANS.md
@@ -1,0 +1,189 @@
+# Span management v2
+
+Berry spans are the local evidence substrate for verification. In v2, a span is no longer just a text snippet. It is a typed, immutable, provenance-bearing evidence record owned by the Berry server.
+
+## Core model
+
+Every span keeps the v1 fields for compatibility:
+
+```text
+sid, text, source, created_at, meta
+```
+
+It now also carries first-class policy and provenance fields:
+
+```text
+eid, kind, source_type, media_type, text_sha256
+locator, snapshot, parents, transform
+trust, status, sensitivity, tags
+```
+
+Important fields:
+
+- `sid` is the human-facing run-local citation ID, for example `S17`.
+- `eid` is a stable hash over text/provenance/lineage metadata.
+- `kind` separates `anchor`, `evidence`, `observation`, `derived`, `assumption`, `decision`, and `audit` records.
+- `locator` stores where the evidence came from, such as path, line range, byte offsets, and encoding.
+- `snapshot` stores source-state facts such as file hash, git commit, git status, baseline reference, and read mode.
+- `parents` and `transform` preserve lineage for extracted spans.
+- `status` supports `active`, `stale`, `superseded`, `tombstoned`, `redacted`, and `quarantined`.
+- `sensitivity` supports `normal`, `secret`, `pii`, and `unknown`.
+
+Span text and provenance are immutable. Mutable operations, such as `mark_span`, only change annotations like status, sensitivity, trust, and tags.
+
+## Anchors are not evidence
+
+`start_run` records the problem statement and deliverable as `kind=anchor`. Anchors capture task intent; they do not prove that work was done.
+
+Server-resolved evidence packs exclude anchors by default. A final answer should cite spans that actually observe the world: file excerpts, test output, source snippets, logs, extracted lines, or other evidence/observation spans.
+
+## Server-resolved verification
+
+Prefer these tools over the legacy raw-span verifier entry points:
+
+```text
+detect_hallucination_run(answer, run_id?, ...)
+audit_trace_budget_run(steps, run_id?, ...)
+```
+
+The run-scoped verifier tools resolve `[S#]` citations from the server-owned run ledger. The agent no longer supplies arbitrary span text to the verifier.
+
+The server rejects evidence packs that contain:
+
+```text
+unknown SIDs
+anchor / assumption / decision / audit spans
+stale, tombstoned, redacted, quarantined spans
+secret or PII spans unless allow_sensitive=true
+untrusted/quarantined spans unless allow_untrusted=true
+non-extractive derived summaries
+prompt-budget-exceeded spans
+```
+
+The verifier receives only the materialized `sid/text` pairs from the evidence pack. The report includes an `evidence_pack` summary with `pack_id`, `text_sha256`, input SIDs, materialized SIDs, exclusions, truncation state, and policy.
+
+## Derived spans
+
+Use `extract_span` to create citable derived spans from a parent span:
+
+```text
+extract_span(parent_sid, selector={"type": "regex", "pattern": "failed|error"})
+extract_span(parent_sid, selector={"type": "line_range", "start_line": 20, "end_line": 35})
+```
+
+No-match extraction creates no span. It returns `matched=false` and `sid=null`; Berry does not create `[no lines matched]` as fake evidence.
+
+Extractive derived spans are citable because they preserve the exact parent text and matched line numbers. Abstractive summary spans are not primary evidence; if cited, the evidence pack surfaces parent spans instead and records the summary as excluded.
+
+`distill_span` remains as a compatibility wrapper around regex extraction.
+
+## File provenance
+
+`add_file_span` captures:
+
+```text
+path and relative path
+line range and byte offsets
+encoding
+file SHA-256
+git commit and git status
+run baseline kind/reference
+read mode
+```
+
+`add_file_span` defaults to `read_mode="baseline"`. In git repos, Berry reads exact bytes from the run baseline commit when available; otherwise it falls back to the worktree and records the fallback reason. Worktree captures are marked with `trust="worktree"` so they cannot be confused with immutable baseline evidence.
+
+If the file is modified in the working tree and the span is captured from the worktree, Berry marks its trust as `worktree`. That is useful evidence, but it should be distinguished from clean baseline evidence. Baseline captures also record `worktree_drift_from_baseline=true` when the current file has diverged from the captured baseline object.
+
+## Persistence and ledgers
+
+Berry persists run state under:
+
+```text
+~/.berry/runs/<run_id>/run.sqlite
+~/.berry/runs/<run_id>/run.json
+~/.berry/runs/<run_id>/evidence.tsv
+~/.berry/runs/<run_id>/attempts.tsv
+~/.berry/runs/<run_id>/claims.tsv
+~/.berry/runs/<run_id>/claim_evidence.tsv
+~/.berry/runs/<run_id>/audits.tsv
+~/.berry/runs/<run_id>/ledger_events.jsonl
+```
+
+`run.sqlite` is now the source of truth. It stores normalized tables for runs, spans, attempts, claims, claim/evidence links, audits, and a tamper-evident `ledger_events` table. Every successful commit appends a snapshot event with a chained event hash and payload hash, so load fails closed if the event log is corrupted or manually edited.
+
+`run.json` and the TSV files are compatibility / inspection exports. They are still written atomically and schema-versioned, but once `run.sqlite` exists the loader prefers SQLite. If a legacy run only has `run.json`, Berry loads it and migrates the in-memory state into the v3 schema.
+
+Persistence failures fail closed with a visible error instead of being silently swallowed. SQLite writes use an IMMEDIATE transaction with WAL mode, foreign keys, payload hashes, and dangling-edge validation.
+
+## Claim/evidence graph
+
+Spans are the evidence substrate; claims are the auditable units built on top of it.
+
+Berry now tracks:
+
+```text
+ClaimRecord
+  cid, text, kind, status, target, latest_audit_id, tags, meta
+
+ClaimEvidenceLink
+  link_id, cid, sid, relation, audit_id, note
+
+AuditRecord
+  audit_id, kind, claim_ids, input_sids, materialized_sids,
+  evidence_pack_id, evidence_pack_hash, verifier_model, policy, result
+```
+
+Allowed claim statuses are:
+
+```text
+open, supported, contradicted, insufficient, downgraded, closed
+```
+
+Allowed claim/evidence relations are:
+
+```text
+supports, contradicts, background, insufficient
+```
+
+`supports` and `contradicts` edges must point at citable evidence spans. `background` edges may point at non-citable anchors, but they do not prove the claim. Verifier audit tools update claim statuses and create audit-linked edges only after the server has resolved a policy-compliant evidence pack.
+
+Use the graph tools for long-running work:
+
+```text
+create_claim(text, target=0.95)
+link_claim_evidence(cid, sid, relation="supports")
+list_claim_evidence(cid=cid)
+audit_claims(claim_ids=[...])
+mark_claim(cid, status="downgraded", reason="target too broad")
+list_claims(status=["open", "insufficient"])
+get_claim(cid)
+list_audits(claim_id=cid)
+```
+
+The intended v2 loop is:
+
+```text
+create claims -> gather spans -> link evidence -> audit claims -> update/downgrade claims -> answer from supported claims plus explicit unknowns
+```
+
+## Search and packing
+
+`query_evidence` replaces raw token-count search with filterable lexical retrieval:
+
+```text
+query_evidence(query, kinds?, source_types?, trust?, status?, include_derived?, include_stale?)
+```
+
+`get_evidence_pack` materializes the exact policy-filtered pack that verifier tools use.
+
+## Compatibility
+
+The legacy tools remain available:
+
+```text
+detect_hallucination(answer, spans, ...)
+audit_trace_budget(steps, spans, ...)
+```
+
+They are useful for local experiments and external callers that do not use Berry runs, but they are lower-trust because the caller supplies the span text. New agent workflows should use the `_run` variants.

--- a/docs/SPANS.md
+++ b/docs/SPANS.md
@@ -97,10 +97,17 @@ If the file is modified in the working tree and the span is captured from the wo
 
 ## Persistence and ledgers
 
-Berry persists run state under:
+Berry persists authoritative run state under:
 
 ```text
 ~/.berry/runs/<run_id>/run.sqlite
+```
+
+`run.sqlite` is the source of truth. It stores normalized tables for runs, spans, attempts, claims, claim/evidence links, audits, and a tamper-evident `ledger_events` table. Hot writes are incremental: a span append upserts only the changed row, stores that row's payload hash, and appends a hash-chained `state_committed` event containing the changed row hash plus the current run metadata hash. Load reconstructs the expected table state by replaying the event chain and fails closed if row payloads, row hashes, metadata hashes, table positions, event payloads, or event-chain links do not match.
+
+Inspection exports are deliberately separated from the hot commit path. By default, Berry does not rewrite full JSON/TSV snapshots after every span because that makes long sessions O(n²). Use the MCP tool `export_run_ledger` or set `BERRY_LEDGER_EXPORT_MODE=sync` when a legacy consumer needs:
+
+```text
 ~/.berry/runs/<run_id>/run.json
 ~/.berry/runs/<run_id>/evidence.tsv
 ~/.berry/runs/<run_id>/attempts.tsv
@@ -110,11 +117,9 @@ Berry persists run state under:
 ~/.berry/runs/<run_id>/ledger_events.jsonl
 ```
 
-`run.sqlite` is now the source of truth. It stores normalized tables for runs, spans, attempts, claims, claim/evidence links, audits, and a tamper-evident `ledger_events` table. Every successful commit appends a snapshot event with a chained event hash and payload hash, so load fails closed if the event log is corrupted or manually edited.
+`BERRY_LEDGER_EXPORT_MODE=hot` writes lightweight head / append-only mirrors on each commit. `BERRY_LEDGER_EXPORT_MODE=off` is the default and keeps the SQLite ledger as the only authoritative hot-path artifact. Legacy JSON-only runs still load and are migrated into the v4 SQLite ledger.
 
-`run.json` and the TSV files are compatibility / inspection exports. They are still written atomically and schema-versioned, but once `run.sqlite` exists the loader prefers SQLite. If a legacy run only has `run.json`, Berry loads it and migrates the in-memory state into the v3 schema.
-
-Persistence failures fail closed with a visible error instead of being silently swallowed. SQLite writes use an IMMEDIATE transaction with WAL mode, foreign keys, payload hashes, and dangling-edge validation.
+Persistence failures fail closed with a visible error instead of being silently swallowed. SQLite writes use an IMMEDIATE transaction with WAL mode, foreign keys, row payload hashes, event-chain verification, cached per-process write connections, and dangling-edge validation.
 
 ## Claim/evidence graph
 

--- a/src/berry/cli.py
+++ b/src/berry/cli.py
@@ -25,6 +25,7 @@ from .clients import (
     write_gemini_settings_json,
 )
 from .config import load_config, save_global_config
+from .installer import actions_to_json, format_actions, install_many, platform_keys
 from .integration import integrate, results_as_json
 from .mcp_server import main as mcp_classic_main
 from .paths import ensure_berry_home, license_path, mcp_env_path
@@ -220,6 +221,70 @@ def cmd_init(args: argparse.Namespace) -> int:
     except Exception as e:
         print(f"warn: auto-auth failed: {e}", file=sys.stderr)
     return 0
+
+
+def _resolve_project_root_for_install(args: argparse.Namespace) -> Path:
+    if getattr(args, "project_root", None):
+        return Path(args.project_root).expanduser().resolve()
+    project_root = _find_repo_root(Path.cwd())
+    allow_non_git = os.environ.get("BERRY_ALLOW_NON_GIT_ROOT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "y",
+        "on",
+    }
+    if not (project_root / ".git").exists() and not allow_non_git:
+        raise SystemExit(
+            "Could not find a .git directory from the current working directory. "
+            "Run from inside a git repo, pass --project-root, or set BERRY_ALLOW_NON_GIT_ROOT=1."
+        )
+    return project_root
+
+
+def cmd_install(args: argparse.Namespace) -> int:
+    if bool(getattr(args, "list_platforms", False)):
+        for key in platform_keys():
+            print(key)
+        return 0
+
+    raw_platforms = list(getattr(args, "platforms", None) or [])
+    if not raw_platforms:
+        raw_platform = getattr(args, "platform", None) or "auto"
+        raw_platforms = [str(raw_platform)]
+    elif getattr(args, "platform", None):
+        raw_platforms.append(str(args.platform))
+
+    project = bool(getattr(args, "project", False))
+    scope = "project" if project else "user"
+    project_root = _resolve_project_root_for_install(args) if project else Path.cwd().resolve()
+
+    try:
+        actions = install_many(
+            raw_platforms,
+            scope=scope,  # type: ignore[arg-type]
+            project_dir=project_root,
+            force=bool(getattr(args, "force", False)),
+            dry_run=bool(getattr(args, "dry_run", False)),
+            berry_command_raw=getattr(args, "berry_command", None),
+            name=str(getattr(args, "name", "berry") or "berry"),
+            install_hooks=not bool(getattr(args, "no_hooks", False)),
+            install_mcp=not bool(getattr(args, "no_mcp", False)),
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    if bool(getattr(args, "json", False)):
+        print(actions_to_json(actions), end="")
+    else:
+        print(format_actions(actions), end="")
+        failed = [a for a in actions if a.status == "failed"]
+        if not failed:
+            print(
+                "Done. Re-run `berry install` after moving/upgrading Berry to refresh embedded paths."
+            )
+
+    return 2 if any(a.status == "failed" for a in actions) else 0
 
 
 def cmd_doctor(_: argparse.Namespace) -> int:
@@ -1052,9 +1117,9 @@ def build_parser() -> argparse.ArgumentParser:
     mcp.add_argument("--transport", choices=["stdio", "sse", "streamable-http"], default="stdio")
     mcp.add_argument(
         "--server",
-        # Berry now ships a single MCP surface (classic). We intentionally keep
-        # the flag for backwards compatibility with older configs that may still
-        # reference "science"/"forge"; those values are treated as aliases.
+        # Berry now ships a single MCP surface (classic). The flag is kept for
+        # backwards compatibility with older configs that may still reference
+        # "science"/"forge"; those values are treated as aliases.
         default="classic",
         help="Which MCP surface to expose (classic). Legacy values may be accepted for older configs.",
     )
@@ -1090,6 +1155,64 @@ def build_parser() -> argparse.ArgumentParser:
         help="Do not write .claude/rules/berry.md (Berry skill file)",
     )
     init.set_defaults(fn=cmd_init)
+
+    install = sub.add_parser(
+        "install",
+        help="Install Berry into an AI coding assistant (multi-platform installer)",
+    )
+    install.add_argument(
+        "platforms",
+        nargs="*",
+        help="Optional platform names. Defaults to auto (Claude Code, or Windows on win32).",
+    )
+    install.add_argument(
+        "--platform",
+        default=None,
+        help="Platform to install (aliases accepted). Use repeated positional names for multiple platforms.",
+    )
+    install.add_argument(
+        "--project",
+        action="store_true",
+        help="Install into the current project instead of the user profile where supported.",
+    )
+    install.add_argument(
+        "--project-root",
+        default=None,
+        help="Project root for --project installs (otherwise inferred from .git).",
+    )
+    install.add_argument("--name", default="berry", help="MCP server name to register")
+    install.add_argument(
+        "--berry-command",
+        default=None,
+        help="Command to embed in generated configs (default: resolved current berry executable).",
+    )
+    install.add_argument(
+        "--force", action="store_true", help="Repair invalid JSON files where safe"
+    )
+    install.add_argument(
+        "--dry-run", action="store_true", help="Show planned writes without writing"
+    )
+    install.add_argument("--json", action="store_true", help="Emit machine-readable action JSON")
+    install.add_argument("--no-hooks", action="store_true", help="Do not install assistant hooks")
+    install.add_argument("--no-mcp", action="store_true", help="Do not update MCP client configs")
+    install.add_argument("--list-platforms", action="store_true", help="Print supported platforms")
+    install.set_defaults(fn=cmd_install)
+
+    # Convenience aliases: `berry codex install`, `berry cursor install`, ...
+    for platform_name in platform_keys():
+        alias = sub.add_parser(platform_name, help=f"{platform_name} platform helpers")
+        alias_sub = alias.add_subparsers(dest=f"{platform_name}_cmd", required=True)
+        alias_install = alias_sub.add_parser("install", help=f"Install Berry for {platform_name}")
+        alias_install.add_argument("--project", action="store_true")
+        alias_install.add_argument("--project-root", default=None)
+        alias_install.add_argument("--name", default="berry")
+        alias_install.add_argument("--berry-command", default=None)
+        alias_install.add_argument("--force", action="store_true")
+        alias_install.add_argument("--dry-run", action="store_true")
+        alias_install.add_argument("--json", action="store_true")
+        alias_install.add_argument("--no-hooks", action="store_true")
+        alias_install.add_argument("--no-mcp", action="store_true")
+        alias_install.set_defaults(fn=cmd_install, platforms=[platform_name], platform=None)
 
     doc = sub.add_parser("doctor", help="Run health checks / self-test")
     doc.set_defaults(fn=cmd_doctor)

--- a/src/berry/enforcement.py
+++ b/src/berry/enforcement.py
@@ -277,9 +277,7 @@ class SpanRecord:
             "snapshot": dict(self.snapshot or {}),
             "parents": list(self.parents or []),
             "transform": (
-                dict(self.transform or {})
-                if isinstance(self.transform, dict)
-                else self.transform
+                dict(self.transform or {}) if isinstance(self.transform, dict) else self.transform
             ),
             "tags": list(self.tags or []),
             "preview": self.preview(limit=preview_chars, redact_sensitive=redact_sensitive),
@@ -289,9 +287,7 @@ class SpanRecord:
         }
         if include_text:
             data["text"] = (
-                "[REDACTED sensitive span]"
-                if redact_sensitive and self.is_sensitive
-                else self.text
+                "[REDACTED sensitive span]" if redact_sensitive and self.is_sensitive else self.text
             )
         return data
 

--- a/src/berry/enforcement.py
+++ b/src/berry/enforcement.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import hashlib
+import json
+import re
 import secrets
 import time
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 
 class EnforcementError(Exception):
@@ -21,13 +24,276 @@ class EnforcementError(Exception):
         return self.message
 
 
+ALLOWED_SPAN_KINDS = {
+    "anchor",
+    "evidence",
+    "observation",
+    "derived",
+    "assumption",
+    "decision",
+    "audit",
+}
+CITABLE_SPAN_KINDS = {"evidence", "observation", "derived"}
+ACTIVE_SPAN_STATUSES = {"active"}
+ALLOWED_SPAN_STATUSES = {
+    "active",
+    "superseded",
+    "stale",
+    "tombstoned",
+    "redacted",
+    "quarantined",
+}
+ALLOWED_SPAN_SENSITIVITY = {"normal", "secret", "pii", "unknown"}
+ALLOWED_CLAIM_KINDS = {"fact", "hypothesis", "decision", "assumption", "unknown"}
+ALLOWED_CLAIM_STATUSES = {
+    "open",
+    "supported",
+    "contradicted",
+    "insufficient",
+    "downgraded",
+    "closed",
+}
+ALLOWED_CLAIM_EVIDENCE_RELATIONS = {
+    "supports",
+    "contradicts",
+    "background",
+    "insufficient",
+}
+ALLOWED_AUDIT_KINDS = {
+    "audit_trace_budget_run",
+    "detect_hallucination_run",
+    "audit_claims",
+    "manual",
+}
+SECRET_RE = re.compile(
+    r"(?i)(-----BEGIN [A-Z ]*PRIVATE KEY-----|"
+    r"\b(?:api[_-]?key|access[_-]?token|secret|password)\s*[=:]\s*['\"]?[^\s'\"]{8,}|"
+    r"\bAKIA[0-9A-Z]{16}\b|"
+    r"\bsk-[A-Za-z0-9_-]{20,}\b|"
+    r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b)"
+)
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(str(text or "").encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def _stable_json_hash(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def detect_span_sensitivity(text: str, explicit: Optional[str] = None) -> str:
+    """Conservatively classify obvious secrets before spans are listed or packed."""
+
+    ex = str(explicit or "").strip().lower()
+    if ex in ALLOWED_SPAN_SENSITIVITY and ex != "unknown":
+        return ex
+    if SECRET_RE.search(str(text or "")):
+        return "secret"
+    return ex if ex in ALLOWED_SPAN_SENSITIVITY else "unknown"
+
+
+def _normalise_kind(*, kind: Optional[str], source: str, meta: Dict[str, Any]) -> str:
+    k = str(kind or "").strip().lower()
+    if not k:
+        mk = str((meta or {}).get("kind") or "").strip().lower()
+        src = str(source or "").strip().lower()
+        if src == "anchor" or mk in {"anchor", "problem", "deliverable"}:
+            k = "anchor"
+        elif src in {"distill", "extract", "derived"}:
+            k = "derived"
+        elif src in {"audit", "verifier"}:
+            k = "audit"
+        else:
+            k = "evidence"
+    return k if k in ALLOWED_SPAN_KINDS else "evidence"
+
+
+def _normalise_status(status: Optional[str]) -> str:
+    s = str(status or "active").strip().lower()
+    return s if s in ALLOWED_SPAN_STATUSES else "active"
+
+
+def _normalise_claim_kind(kind: Optional[str]) -> str:
+    k = str(kind or "fact").strip().lower()
+    return k if k in ALLOWED_CLAIM_KINDS else "unknown"
+
+
+def _normalise_claim_status(status: Optional[str]) -> str:
+    s = str(status or "open").strip().lower()
+    return s if s in ALLOWED_CLAIM_STATUSES else "open"
+
+
+def _normalise_claim_relation(relation: Optional[str]) -> str:
+    r = str(relation or "supports").strip().lower()
+    return r if r in ALLOWED_CLAIM_EVIDENCE_RELATIONS else "background"
+
+
+def _normalise_audit_kind(kind: Optional[str]) -> str:
+    k = str(kind or "manual").strip().lower()
+    return k if k in ALLOWED_AUDIT_KINDS else "manual"
+
+
+def _validate_claim_target(value: Any) -> float:
+    try:
+        target = float(value if value is not None else 0.95)
+    except Exception as exc:
+        raise EnforcementError(
+            f"target must be a finite probability in (0, 1), got {value!r}"
+        ) from exc
+    if not (0.0 < target < 1.0):
+        raise EnforcementError(f"target must be a finite probability in (0, 1), got {value!r}")
+    return target
+
+
+def _normalise_tags(tags: Optional[Iterable[str]]) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for raw in tags or []:
+        tag = str(raw or "").strip()
+        if not tag or tag in seen:
+            continue
+        seen.add(tag)
+        out.append(tag)
+    return out
+
+
 @dataclass(frozen=True)
 class SpanRecord:
+    """Run-local evidence object.
+
+    v1 Berry treated a span as only ``sid/text/source/meta``.  v2 keeps those
+    fields for compatibility, but adds first-class provenance, trust, lineage,
+    sensitivity, and lifecycle fields so the verifier can resolve evidence from
+    the server-owned run ledger instead of trusting caller-supplied snippets.
+    """
+
     sid: str
     text: str
     source: str
     created_at: float
     meta: Dict[str, Any] = field(default_factory=dict)
+
+    # v2 provenance and policy fields.  Defaults keep old serialized runs loadable.
+    eid: str = ""
+    kind: str = ""
+    source_type: str = ""
+    media_type: str = "text/plain"
+    text_sha256: str = ""
+    locator: Dict[str, Any] = field(default_factory=dict)
+    snapshot: Dict[str, Any] = field(default_factory=dict)
+    parents: List[str] = field(default_factory=list)
+    transform: Optional[Dict[str, Any]] = None
+    trust: str = ""
+    status: str = "active"
+    sensitivity: str = "unknown"
+    tags: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        meta = dict(self.meta or {})
+        source = str(self.source or self.source_type or "manual")
+        source_type = str(self.source_type or source or "manual")
+        kind = _normalise_kind(kind=self.kind, source=source, meta=meta)
+        text = str(self.text or "")
+        text_sha = str(self.text_sha256 or _sha256_text(text))
+        locator = dict(self.locator or {})
+        snapshot = dict(self.snapshot or {})
+        parents = [str(p).strip() for p in (self.parents or []) if str(p).strip()]
+        transform = dict(self.transform) if isinstance(self.transform, dict) else self.transform
+        trust = str(self.trust or "").strip().lower()
+        if not trust:
+            trust = "manual" if kind == "anchor" else "derived" if kind == "derived" else "primary"
+        sensitivity = detect_span_sensitivity(text, self.sensitivity)
+        tags = _normalise_tags(self.tags)
+        status = _normalise_status(self.status)
+        eid = str(self.eid or "").strip()
+        if not eid:
+            eid = _stable_json_hash(
+                {
+                    "text_sha256": text_sha,
+                    "source_type": source_type,
+                    "media_type": str(self.media_type or "text/plain"),
+                    "locator": locator,
+                    "snapshot": snapshot,
+                    "parents": parents,
+                    "transform": transform,
+                }
+            )
+
+        object.__setattr__(self, "source", source)
+        object.__setattr__(self, "source_type", source_type)
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "media_type", str(self.media_type or "text/plain"))
+        object.__setattr__(self, "text_sha256", text_sha)
+        object.__setattr__(self, "locator", locator)
+        object.__setattr__(self, "snapshot", snapshot)
+        object.__setattr__(self, "parents", parents)
+        object.__setattr__(self, "transform", transform)
+        object.__setattr__(self, "trust", trust)
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "sensitivity", sensitivity)
+        object.__setattr__(self, "tags", tags)
+        object.__setattr__(self, "eid", eid)
+
+    @property
+    def is_active(self) -> bool:
+        return self.status in ACTIVE_SPAN_STATUSES
+
+    @property
+    def is_sensitive(self) -> bool:
+        return self.sensitivity in {"secret", "pii"}
+
+    @property
+    def is_citable(self) -> bool:
+        if not self.is_active or self.kind not in CITABLE_SPAN_KINDS:
+            return False
+        if self.kind == "derived":
+            t = (self.transform or {}).get("type") if isinstance(self.transform, dict) else None
+            return str(t or "").strip().lower() in {"regex_extract", "line_range", "byte_range"}
+        return True
+
+    def preview(self, *, limit: int = 160, redact_sensitive: bool = True) -> str:
+        if redact_sensitive and self.is_sensitive:
+            return "[REDACTED sensitive span]"
+        return self.text.strip().replace("\n", " ")[: max(0, int(limit))]
+
+    def to_public_dict(
+        self, *, include_text: bool = False, preview_chars: int = 160, redact_sensitive: bool = True
+    ) -> Dict[str, Any]:
+        data = {
+            "sid": self.sid,
+            "eid": self.eid,
+            "source": self.source,
+            "source_type": self.source_type,
+            "kind": self.kind,
+            "trust": self.trust,
+            "status": self.status,
+            "sensitivity": self.sensitivity,
+            "created_at": self.created_at,
+            "chars": len(self.text),
+            "text_sha256": self.text_sha256,
+            "locator": dict(self.locator or {}),
+            "snapshot": dict(self.snapshot or {}),
+            "parents": list(self.parents or []),
+            "transform": (
+                dict(self.transform or {})
+                if isinstance(self.transform, dict)
+                else self.transform
+            ),
+            "tags": list(self.tags or []),
+            "preview": self.preview(limit=preview_chars, redact_sensitive=redact_sensitive),
+            "meta": dict(self.meta or {}),
+            # Back-compat convenience fields used by older clients.
+            "source_legacy": self.source,
+        }
+        if include_text:
+            data["text"] = (
+                "[REDACTED sensitive span]"
+                if redact_sensitive and self.is_sensitive
+                else self.text
+            )
+        return data
 
 
 @dataclass(frozen=True)
@@ -63,6 +329,154 @@ class AttemptRecord:
     objective_value: str = ""
     result_summary: str = ""
     next_step: str = ""
+
+
+@dataclass(frozen=True)
+class ClaimRecord:
+    """Structured factual unit tracked across evidence gathering and audits."""
+
+    cid: str
+    text: str
+    kind: str = "fact"
+    status: str = "open"
+    target: float = 0.95
+    created_at: float = 0.0
+    updated_at: float = 0.0
+    source: str = "manual"
+    latest_audit_id: str = ""
+    tags: List[str] = field(default_factory=list)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        now = time.time()
+        text = str(self.text or "").strip()
+        object.__setattr__(self, "text", text)
+        object.__setattr__(self, "kind", _normalise_claim_kind(self.kind))
+        object.__setattr__(self, "status", _normalise_claim_status(self.status))
+        object.__setattr__(self, "target", _validate_claim_target(self.target))
+        object.__setattr__(self, "created_at", float(self.created_at or now))
+        object.__setattr__(self, "updated_at", float(self.updated_at or self.created_at or now))
+        object.__setattr__(self, "source", str(self.source or "manual").strip() or "manual")
+        object.__setattr__(self, "latest_audit_id", str(self.latest_audit_id or "").strip())
+        object.__setattr__(self, "tags", _normalise_tags(self.tags))
+        object.__setattr__(self, "meta", dict(self.meta or {}))
+
+    def to_public_dict(self) -> Dict[str, Any]:
+        return {
+            "cid": self.cid,
+            "claim_id": self.cid,
+            "text": self.text,
+            "kind": self.kind,
+            "status": self.status,
+            "target": self.target,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "source": self.source,
+            "latest_audit_id": self.latest_audit_id,
+            "tags": list(self.tags or []),
+            "meta": dict(self.meta or {}),
+        }
+
+
+@dataclass(frozen=True)
+class ClaimEvidenceLink:
+    """Typed relation between a claim and a run-owned evidence span."""
+
+    link_id: str
+    cid: str
+    sid: str
+    relation: str = "supports"
+    created_at: float = 0.0
+    created_by: str = "manual"
+    audit_id: str = ""
+    note: str = ""
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "cid", str(self.cid or "").strip())
+        object.__setattr__(self, "sid", str(self.sid or "").strip())
+        object.__setattr__(self, "relation", _normalise_claim_relation(self.relation))
+        object.__setattr__(self, "created_at", float(self.created_at or time.time()))
+        object.__setattr__(self, "created_by", str(self.created_by or "manual").strip() or "manual")
+        object.__setattr__(self, "audit_id", str(self.audit_id or "").strip())
+        object.__setattr__(self, "note", str(self.note or "").strip())
+        object.__setattr__(self, "meta", dict(self.meta or {}))
+
+    def to_public_dict(self) -> Dict[str, Any]:
+        return {
+            "link_id": self.link_id,
+            "cid": self.cid,
+            "claim_id": self.cid,
+            "sid": self.sid,
+            "relation": self.relation,
+            "created_at": self.created_at,
+            "created_by": self.created_by,
+            "audit_id": self.audit_id,
+            "note": self.note,
+            "meta": dict(self.meta or {}),
+        }
+
+
+@dataclass(frozen=True)
+class AuditRecord:
+    """Verifier audit metadata for reproducible claim/evidence decisions."""
+
+    audit_id: str
+    kind: str
+    created_at: float
+    claim_ids: List[str] = field(default_factory=list)
+    input_sids: List[str] = field(default_factory=list)
+    materialized_sids: List[str] = field(default_factory=list)
+    evidence_pack_id: str = ""
+    evidence_pack_hash: str = ""
+    verifier_model: str = ""
+    policy: Dict[str, Any] = field(default_factory=dict)
+    result: Dict[str, Any] = field(default_factory=dict)
+    audit_sid: str = ""
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "kind", _normalise_audit_kind(self.kind))
+        object.__setattr__(self, "created_at", float(self.created_at or time.time()))
+        object.__setattr__(
+            self,
+            "claim_ids",
+            [str(v).strip() for v in (self.claim_ids or []) if str(v).strip()],
+        )
+        object.__setattr__(
+            self,
+            "input_sids",
+            [str(v).strip() for v in (self.input_sids or []) if str(v).strip()],
+        )
+        object.__setattr__(
+            self,
+            "materialized_sids",
+            [str(v).strip() for v in (self.materialized_sids or []) if str(v).strip()],
+        )
+        object.__setattr__(self, "evidence_pack_id", str(self.evidence_pack_id or "").strip())
+        object.__setattr__(self, "evidence_pack_hash", str(self.evidence_pack_hash or "").strip())
+        object.__setattr__(self, "verifier_model", str(self.verifier_model or "").strip())
+        object.__setattr__(self, "policy", dict(self.policy or {}))
+        object.__setattr__(self, "result", dict(self.result or {}))
+        object.__setattr__(self, "audit_sid", str(self.audit_sid or "").strip())
+        object.__setattr__(self, "meta", dict(self.meta or {}))
+
+    def to_public_dict(self) -> Dict[str, Any]:
+        return {
+            "audit_id": self.audit_id,
+            "kind": self.kind,
+            "created_at": self.created_at,
+            "claim_ids": list(self.claim_ids or []),
+            "input_sids": list(self.input_sids or []),
+            "materialized_sids": list(self.materialized_sids or []),
+            "evidence_pack_id": self.evidence_pack_id,
+            "evidence_pack_hash": self.evidence_pack_hash,
+            "verifier_model": self.verifier_model,
+            "policy": dict(self.policy or {}),
+            "result": dict(self.result or {}),
+            "audit_sid": self.audit_sid,
+            "meta": dict(self.meta or {}),
+        }
 
 
 @dataclass(frozen=True)
@@ -109,6 +523,13 @@ class RunState:
     pending_writes: Dict[str, PendingWrite] = field(default_factory=dict)
     attempts: List[AttemptRecord] = field(default_factory=list)
     next_attempt_idx: int = 0
+    claims: Dict[str, ClaimRecord] = field(default_factory=dict)
+    claim_order: List[str] = field(default_factory=list)
+    next_claim_idx: int = 0
+    claim_evidence_links: List[ClaimEvidenceLink] = field(default_factory=list)
+    next_claim_link_idx: int = 0
+    audits: List[AuditRecord] = field(default_factory=list)
+    next_audit_idx: int = 0
 
     # Unified approval system (per-run grants).
     # - pending_grants maps token -> PendingGrant
@@ -131,8 +552,9 @@ class RunState:
     # Science-server metadata
     # ------------------------------------------------------------------
     # Baseline snapshot information used for evidence provenance.
-    # If `baseline_kind == 'git'`, repo evidence should be read from `baseline_ref` (a git commit hash)
-    # rather than the working tree, to prevent evidence-poisoning via self-authored files.
+    # If `baseline_kind == 'git'`, repo evidence should be read from `baseline_ref`
+    # (a git commit hash) rather than the working tree, to prevent
+    # evidence-poisoning via self-authored files.
     baseline_kind: str = "fs"  # 'git'|'fs'
     baseline_ref: Optional[str] = None
 
@@ -189,6 +611,13 @@ class RunStore:
         run.spans_version += 1
         run.attempts.clear()
         run.next_attempt_idx = 0
+        run.claims.clear()
+        run.claim_order.clear()
+        run.next_claim_idx = 0
+        run.claim_evidence_links.clear()
+        run.next_claim_link_idx = 0
+        run.audits.clear()
+        run.next_audit_idx = 0
         run.microplan = None
         run.microplan_audit = None
         run.pending_writes.clear()
@@ -291,40 +720,432 @@ class RunStore:
             )
         return out
 
+    # ------------------------------------------------------------------
+    # Claim / evidence graph
+    # ------------------------------------------------------------------
+
+    def create_claim(
+        self,
+        *,
+        run: RunState,
+        text: str,
+        kind: str = "fact",
+        target: float = 0.95,
+        status: str = "open",
+        source: str = "manual",
+        tags: Optional[Sequence[str]] = None,
+        meta: Optional[Dict[str, Any]] = None,
+        cid: Optional[str] = None,
+    ) -> ClaimRecord:
+        claim_text = str(text or "").strip()
+        if not claim_text:
+            raise EnforcementError("claim text is required")
+        clean_cid = str(cid or "").strip()
+        if clean_cid:
+            if clean_cid in run.claims:
+                raise EnforcementError(f"Claim id already exists: {clean_cid}")
+            if clean_cid.startswith("C") and clean_cid[1:].isdigit():
+                run.next_claim_idx = max(run.next_claim_idx, int(clean_cid[1:]) + 1)
+        else:
+            clean_cid = f"C{run.next_claim_idx}"
+            run.next_claim_idx += 1
+        rec = ClaimRecord(
+            cid=clean_cid,
+            text=claim_text,
+            kind=kind,
+            status=status,
+            target=target,
+            created_at=time.time(),
+            updated_at=time.time(),
+            source=source,
+            tags=list(tags or []),
+            meta=dict(meta or {}),
+        )
+        run.claims[rec.cid] = rec
+        run.claim_order.append(rec.cid)
+        return rec
+
+    def get_claim(self, *, run: RunState, cid: str) -> ClaimRecord:
+        key = str(cid or "").strip()
+        if not key:
+            raise EnforcementError("cid is required")
+        if key not in run.claims:
+            raise EnforcementError(f"Unknown claim id: {key}")
+        return run.claims[key]
+
+    def update_claim(
+        self,
+        *,
+        run: RunState,
+        cid: str,
+        status: Optional[str] = None,
+        kind: Optional[str] = None,
+        target: Optional[float] = None,
+        latest_audit_id: Optional[str] = None,
+        tags_add: Optional[Sequence[str]] = None,
+        tags_remove: Optional[Sequence[str]] = None,
+        meta_update: Optional[Dict[str, Any]] = None,
+    ) -> ClaimRecord:
+        rec = self.get_claim(run=run, cid=cid)
+        tags = list(rec.tags or [])
+        remove = {str(t).strip() for t in (tags_remove or []) if str(t).strip()}
+        tags = [t for t in tags if t not in remove]
+        for raw in tags_add or []:
+            tag = str(raw or "").strip()
+            if tag and tag not in tags:
+                tags.append(tag)
+        meta = dict(rec.meta or {})
+        if meta_update:
+            meta.update(dict(meta_update))
+        updated = replace(
+            rec,
+            kind=_normalise_claim_kind(kind) if kind is not None else rec.kind,
+            status=_normalise_claim_status(status) if status is not None else rec.status,
+            target=_validate_claim_target(target) if target is not None else rec.target,
+            latest_audit_id=(
+                str(latest_audit_id or "").strip()
+                if latest_audit_id is not None
+                else rec.latest_audit_id
+            ),
+            updated_at=time.time(),
+            tags=tags,
+            meta=meta,
+        )
+        run.claims[rec.cid] = updated
+        return updated
+
+    def list_claims(
+        self,
+        *,
+        run: RunState,
+        limit: int = 200,
+        status: Optional[Sequence[str]] = None,
+        kinds: Optional[Sequence[str]] = None,
+        include_evidence: bool = True,
+    ) -> List[Dict[str, Any]]:
+        status_set = {str(s).strip().lower() for s in (status or []) if str(s).strip()}
+        kind_set = {str(k).strip().lower() for k in (kinds or []) if str(k).strip()}
+        out: List[Dict[str, Any]] = []
+        limit_n = max(1, int(limit or 200))
+        for cid in run.claim_order:
+            if len(out) >= limit_n:
+                break
+            rec = run.claims.get(cid)
+            if rec is None:
+                continue
+            if status_set and rec.status not in status_set:
+                continue
+            if kind_set and rec.kind not in kind_set:
+                continue
+            data = rec.to_public_dict()
+            if include_evidence:
+                data["evidence"] = [
+                    link.to_public_dict()
+                    for link in run.claim_evidence_links
+                    if link.cid == rec.cid
+                ]
+            out.append(data)
+        return out
+
+    def link_claim_evidence(
+        self,
+        *,
+        run: RunState,
+        cid: str,
+        sid: str,
+        relation: str = "supports",
+        created_by: str = "manual",
+        audit_id: str = "",
+        note: str = "",
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> ClaimEvidenceLink:
+        claim = self.get_claim(run=run, cid=cid)
+        span = self.get_span(run=run, sid=sid)
+        rel = _normalise_claim_relation(relation)
+        if rel in {"supports", "contradicts"} and not span.is_citable:
+            raise EnforcementError(
+                f"Span {span.sid} is not citable as {rel} evidence "
+                f"(kind={span.kind}, status={span.status}, sensitivity={span.sensitivity})"
+            )
+        # De-duplicate identical active graph edges; update audit/note metadata by creating
+        # a new link only when the relation or audit differs.  This keeps repeated audit
+        # calls from accumulating an unbounded pile of identical manual edges.
+        for existing in run.claim_evidence_links:
+            if (
+                existing.cid == claim.cid
+                and existing.sid == span.sid
+                and existing.relation == rel
+                and existing.audit_id == str(audit_id or "").strip()
+            ):
+                return existing
+        link = ClaimEvidenceLink(
+            link_id=f"L{run.next_claim_link_idx}",
+            cid=claim.cid,
+            sid=span.sid,
+            relation=rel,
+            created_at=time.time(),
+            created_by=created_by,
+            audit_id=audit_id,
+            note=note,
+            meta=dict(meta or {}),
+        )
+        run.next_claim_link_idx += 1
+        run.claim_evidence_links.append(link)
+        return link
+
+    def list_claim_evidence(
+        self,
+        *,
+        run: RunState,
+        cid: Optional[str] = None,
+        sid: Optional[str] = None,
+        relation: Optional[Sequence[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        rel_set = {str(r).strip().lower() for r in (relation or []) if str(r).strip()}
+        cid_key = str(cid or "").strip()
+        sid_key = str(sid or "").strip()
+        out: List[Dict[str, Any]] = []
+        for link in run.claim_evidence_links:
+            if cid_key and link.cid != cid_key:
+                continue
+            if sid_key and link.sid != sid_key:
+                continue
+            if rel_set and link.relation not in rel_set:
+                continue
+            out.append(link.to_public_dict())
+        return out
+
+    def record_audit(
+        self,
+        *,
+        run: RunState,
+        kind: str,
+        claim_ids: Optional[Sequence[str]] = None,
+        input_sids: Optional[Sequence[str]] = None,
+        materialized_sids: Optional[Sequence[str]] = None,
+        evidence_pack_id: str = "",
+        evidence_pack_hash: str = "",
+        verifier_model: str = "",
+        policy: Optional[Dict[str, Any]] = None,
+        result: Optional[Dict[str, Any]] = None,
+        audit_sid: str = "",
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> AuditRecord:
+        cleaned_claims: List[str] = []
+        for raw in claim_ids or []:
+            cid = str(raw or "").strip()
+            if not cid:
+                continue
+            if cid not in run.claims:
+                raise EnforcementError(f"Unknown claim id: {cid}")
+            if cid not in cleaned_claims:
+                cleaned_claims.append(cid)
+        cleaned_inputs: List[str] = []
+        for raw in input_sids or []:
+            sid = str(raw or "").strip()
+            if not sid:
+                continue
+            if sid not in run.spans:
+                raise EnforcementError(f"Unknown input span id: {sid}")
+            if sid not in cleaned_inputs:
+                cleaned_inputs.append(sid)
+        cleaned_materialized: List[str] = []
+        for raw in materialized_sids or []:
+            sid = str(raw or "").strip()
+            if not sid:
+                continue
+            if sid not in run.spans:
+                raise EnforcementError(f"Unknown materialized span id: {sid}")
+            if sid not in cleaned_materialized:
+                cleaned_materialized.append(sid)
+        if audit_sid:
+            self.get_span(run=run, sid=audit_sid)
+        audit = AuditRecord(
+            audit_id=f"V{run.next_audit_idx}",
+            kind=kind,
+            created_at=time.time(),
+            claim_ids=cleaned_claims,
+            input_sids=cleaned_inputs,
+            materialized_sids=cleaned_materialized,
+            evidence_pack_id=evidence_pack_id,
+            evidence_pack_hash=evidence_pack_hash,
+            verifier_model=verifier_model,
+            policy=dict(policy or {}),
+            result=dict(result or {}),
+            audit_sid=audit_sid,
+            meta=dict(meta or {}),
+        )
+        run.next_audit_idx += 1
+        run.audits.append(audit)
+        return audit
+
+    def list_audits(
+        self,
+        *,
+        run: RunState,
+        claim_id: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        cid = str(claim_id or "").strip()
+        out: List[Dict[str, Any]] = []
+        for audit in reversed(run.audits):
+            if len(out) >= max(1, int(limit or 100)):
+                break
+            if cid and cid not in audit.claim_ids:
+                continue
+            out.append(audit.to_public_dict())
+        return out
+
+    def claim_steps(
+        self,
+        *,
+        run: RunState,
+        claim_ids: Optional[Sequence[str]] = None,
+        max_claims: int = 25,
+        evidence_relations: Optional[Sequence[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Build verifier steps from the structured claim/evidence graph."""
+
+        relation_set = {
+            _normalise_claim_relation(r) for r in (evidence_relations or ["supports", "background"])
+        }
+        requested = [str(cid).strip() for cid in (claim_ids or []) if str(cid).strip()]
+        if not requested:
+            requested = [
+                cid
+                for cid in run.claim_order
+                if run.claims.get(cid) and run.claims[cid].status in {"open", "insufficient"}
+            ]
+        out: List[Dict[str, Any]] = []
+        for cid in requested:
+            claim = self.get_claim(run=run, cid=cid)
+            cites: List[str] = []
+            for link in run.claim_evidence_links:
+                if link.cid != cid or link.relation not in relation_set:
+                    continue
+                span = run.spans.get(link.sid)
+                # Background edges are graph annotations, not proof.  They may
+                # legally point at anchors or decisions, but verifier steps must
+                # only cite spans that would pass the evidence-pack policy.
+                if span is None or not span.is_citable:
+                    continue
+                if link.sid not in cites:
+                    cites.append(link.sid)
+            out.append(
+                {
+                    "idx": len(out),
+                    "claim_id": claim.cid,
+                    "claim": claim.text,
+                    "cites": cites,
+                    "confidence": claim.target,
+                }
+            )
+            if len(out) >= max(1, int(max_claims or 25)):
+                break
+        return out
+
     def add_span(
-        self, *, run: RunState, text: str, source: str, meta: Optional[Dict[str, Any]] = None
+        self,
+        *,
+        run: RunState,
+        text: str,
+        source: str,
+        meta: Optional[Dict[str, Any]] = None,
+        kind: Optional[str] = None,
+        source_type: Optional[str] = None,
+        media_type: str = "text/plain",
+        locator: Optional[Dict[str, Any]] = None,
+        snapshot: Optional[Dict[str, Any]] = None,
+        parents: Optional[Sequence[str]] = None,
+        transform: Optional[Dict[str, Any]] = None,
+        trust: Optional[str] = None,
+        status: str = "active",
+        sensitivity: Optional[str] = None,
+        tags: Optional[Sequence[str]] = None,
     ) -> SpanRecord:
         t = str(text or "")
         if not t.strip():
             raise EnforcementError("Span text is empty")
+
+        cleaned_parents: List[str] = []
+        for raw in parents or []:
+            psid = str(raw or "").strip()
+            if not psid:
+                continue
+            if psid not in run.spans:
+                raise EnforcementError(f"Unknown parent span id: {psid}")
+            if psid not in cleaned_parents:
+                cleaned_parents.append(psid)
+
+        inherited_sensitivity: Optional[str] = sensitivity
+        if not inherited_sensitivity and cleaned_parents:
+            parent_sens = {run.spans[p].sensitivity for p in cleaned_parents}
+            if "secret" in parent_sens:
+                inherited_sensitivity = "secret"
+            elif "pii" in parent_sens:
+                inherited_sensitivity = "pii"
+
         sid = f"S{run.next_span_idx}"
         run.next_span_idx += 1
         rec = SpanRecord(
             sid=sid,
             text=t,
-            source=str(source or "manual"),
+            source=str(source or source_type or "manual"),
             created_at=time.time(),
             meta=dict(meta or {}),
+            kind=kind or "",
+            source_type=str(source_type or source or "manual"),
+            media_type=str(media_type or "text/plain"),
+            locator=dict(locator or {}),
+            snapshot=dict(snapshot or {}),
+            parents=cleaned_parents,
+            transform=dict(transform or {}) if transform else None,
+            trust=str(trust or ""),
+            status=status,
+            sensitivity=inherited_sensitivity or "unknown",
+            tags=list(tags or []),
         )
         run.spans[sid] = rec
         run.span_order.append(sid)
         run.spans_version += 1
         return rec
 
-    def list_spans(self, *, run: RunState, limit: int = 200) -> List[Dict[str, Any]]:
+    def list_spans(
+        self,
+        *,
+        run: RunState,
+        limit: int = 200,
+        kinds: Optional[Sequence[str]] = None,
+        source_types: Optional[Sequence[str]] = None,
+        trust: Optional[Sequence[str]] = None,
+        status: Optional[Sequence[str]] = None,
+        include_sensitive_preview: bool = False,
+    ) -> List[Dict[str, Any]]:
+        kind_set = {str(k).strip().lower() for k in (kinds or []) if str(k).strip()}
+        source_set = {str(k).strip().lower() for k in (source_types or []) if str(k).strip()}
+        trust_set = {str(k).strip().lower() for k in (trust or []) if str(k).strip()}
+        status_set = {str(k).strip().lower() for k in (status or []) if str(k).strip()}
+
         out: List[Dict[str, Any]] = []
-        for sid in run.span_order[: max(1, int(limit or 200))]:
+        limit_n = max(1, int(limit or 200))
+        for sid in run.span_order:
+            if len(out) >= limit_n:
+                break
             s = run.spans[sid]
-            preview = s.text.strip().replace("\n", " ")
+            if kind_set and s.kind not in kind_set:
+                continue
+            if source_set and s.source_type not in source_set:
+                continue
+            if trust_set and s.trust not in trust_set:
+                continue
+            if status_set and s.status not in status_set:
+                continue
             out.append(
-                {
-                    "sid": s.sid,
-                    "source": s.source,
-                    "created_at": s.created_at,
-                    "chars": len(s.text),
-                    "preview": preview[:160],
-                    "meta": s.meta,
-                }
+                s.to_public_dict(
+                    include_text=False,
+                    preview_chars=160,
+                    redact_sensitive=not include_sensitive_preview,
+                )
             )
         return out
 
@@ -335,6 +1156,331 @@ class RunStore:
         if key not in run.spans:
             raise EnforcementError(f"Unknown span id: {key}")
         return run.spans[key]
+
+    def mark_span(
+        self,
+        *,
+        run: RunState,
+        sid: str,
+        status: Optional[str] = None,
+        sensitivity: Optional[str] = None,
+        tags_add: Optional[Sequence[str]] = None,
+        tags_remove: Optional[Sequence[str]] = None,
+        trust: Optional[str] = None,
+    ) -> SpanRecord:
+        rec = self.get_span(run=run, sid=sid)
+        tags = list(rec.tags or [])
+        remove = {str(t).strip() for t in (tags_remove or []) if str(t).strip()}
+        tags = [t for t in tags if t not in remove]
+        for raw in tags_add or []:
+            tag = str(raw or "").strip()
+            if tag and tag not in tags:
+                tags.append(tag)
+        updated = replace(
+            rec,
+            status=_normalise_status(status) if status is not None else rec.status,
+            sensitivity=detect_span_sensitivity(rec.text, sensitivity)
+            if sensitivity is not None
+            else rec.sensitivity,
+            tags=tags,
+            trust=str(trust or rec.trust).strip().lower(),
+        )
+        run.spans[rec.sid] = updated
+        run.spans_version += 1
+        return updated
+
+    def extract_span(
+        self,
+        *,
+        run: RunState,
+        parent_sid: str,
+        selector: Dict[str, Any],
+        reason: str = "",
+        source: str = "extract",
+        max_lines: int = 200,
+        tags: Optional[Sequence[str]] = None,
+    ) -> Dict[str, Any]:
+        parent = self.get_span(run=run, sid=parent_sid)
+        sel = dict(selector or {})
+        typ = str(sel.get("type") or sel.get("selector_type") or "regex").strip().lower()
+        max_n = max(1, int(max_lines or 200))
+        lines = parent.text.splitlines()
+        matched_lines: List[int] = []
+
+        if typ in {"regex", "regex_extract"}:
+            pattern = str(sel.get("pattern") or "")
+            if not pattern:
+                raise EnforcementError("selector.pattern is required for regex extraction")
+            fl = 0
+            flags = str(sel.get("flags") or "i")
+            if "i" in flags:
+                fl |= re.IGNORECASE
+            if "m" in flags:
+                fl |= re.MULTILINE
+            try:
+                rx = re.compile(pattern, fl)
+            except Exception as exc:
+                raise EnforcementError(f"Invalid regex pattern: {exc}")
+            for i, line in enumerate(lines, start=1):
+                if rx.search(line):
+                    matched_lines.append(i)
+                    if len(matched_lines) >= max_n:
+                        break
+        elif typ in {"line_range", "lines"}:
+            start = max(1, int(sel.get("start_line") or sel.get("start") or 1))
+            end = max(start, int(sel.get("end_line") or sel.get("end") or start))
+            matched_lines = list(range(start, min(end, len(lines)) + 1))[:max_n]
+        else:
+            raise EnforcementError(f"Unsupported selector type: {typ}")
+
+        if not matched_lines:
+            return {
+                "matched": False,
+                "sid": None,
+                "parent_sid": parent.sid,
+                "matches": [],
+                "message": "No lines matched; no evidence span created.",
+            }
+
+        text = "\n".join(lines[i - 1] for i in matched_lines if 1 <= i <= len(lines)).strip()
+        if not text:
+            return {
+                "matched": False,
+                "sid": None,
+                "parent_sid": parent.sid,
+                "matches": [],
+                "message": "Selected lines were empty; no evidence span created.",
+            }
+
+        transform = {
+            "type": "line_range" if typ in {"line_range", "lines"} else "regex_extract",
+            "selector": sel,
+            "reason": str(reason or ""),
+            "matched_lines": matched_lines,
+        }
+        locator = dict(parent.locator or {})
+        locator.update({"parent_sid": parent.sid, "matched_lines": matched_lines})
+        rec = self.add_span(
+            run=run,
+            text=text,
+            source=str(source or "extract"),
+            source_type="extract",
+            kind="derived",
+            media_type=parent.media_type,
+            locator=locator,
+            snapshot=dict(parent.snapshot or {}),
+            parents=[parent.sid],
+            transform=transform,
+            trust="derived",
+            sensitivity=parent.sensitivity,
+            tags=list(tags or []) + ["derived"],
+            meta={"parent_sid": parent.sid, "selector": sel, "reason": str(reason or "")},
+        )
+        return {
+            "matched": True,
+            "sid": rec.sid,
+            "parent_sid": parent.sid,
+            "matches": [{"line": i, "text": lines[i - 1]} for i in matched_lines],
+            "span": rec.to_public_dict(include_text=False),
+        }
+
+    def _evidence_exclusion_reason(
+        self,
+        span: SpanRecord,
+        *,
+        allowed_kinds: Sequence[str],
+        allow_sensitive: bool,
+        include_stale: bool,
+        allow_untrusted: bool,
+    ) -> Optional[str]:
+        allowed = {str(k).strip().lower() for k in allowed_kinds if str(k).strip()}
+        if span.status != "active":
+            if span.status == "stale" and include_stale:
+                pass
+            else:
+                return f"status:{span.status}"
+        if span.kind not in allowed:
+            return f"kind:{span.kind}"
+        if span.is_sensitive and not allow_sensitive:
+            return f"sensitivity:{span.sensitivity}"
+        if span.trust in {"quarantined", "untrusted"} and not allow_untrusted:
+            return f"trust:{span.trust}"
+        if span.kind == "derived" and not span.is_citable:
+            return "derived_not_extractively_citable"
+        return None
+
+    def resolve_evidence_pack(
+        self,
+        *,
+        run: RunState,
+        sids: Sequence[str],
+        max_chars: int = 12000,
+        allowed_kinds: Optional[Sequence[str]] = None,
+        allow_sensitive: bool = False,
+        include_stale: bool = False,
+        allow_untrusted: bool = False,
+        include_derived_parents: bool = True,
+    ) -> Dict[str, Any]:
+        """Resolve run-owned SIDs into a verifier-safe evidence pack.
+
+        The pack is fail-closed: callers get explicit exclusions for unknown,
+        inactive, sensitive, non-evidence, or non-extractive derived spans.
+        """
+
+        input_sids: List[str] = []
+        for raw in sids or []:
+            sid = str(raw or "").strip()
+            if sid and sid not in input_sids:
+                input_sids.append(sid)
+
+        allowed = list(allowed_kinds or ["evidence", "observation", "derived"])
+        excluded: List[Dict[str, str]] = []
+        materialized: List[SpanRecord] = []
+        seen: set[str] = set()
+
+        def add_candidate(sid: str, *, cited_by: Optional[str] = None) -> None:
+            if sid in seen:
+                return
+            if sid not in run.spans:
+                excluded.append({"sid": sid, "reason": "unknown"})
+                return
+            span = run.spans[sid]
+            reason = self._evidence_exclusion_reason(
+                span,
+                allowed_kinds=allowed,
+                allow_sensitive=allow_sensitive,
+                include_stale=include_stale,
+                allow_untrusted=allow_untrusted,
+            )
+            if reason:
+                item = {"sid": sid, "reason": reason}
+                if cited_by:
+                    item["cited_by"] = cited_by
+                excluded.append(item)
+                # If a non-citable derived summary is cited, surface its primary
+                # parents so the user can audit against primary evidence instead.
+                if include_derived_parents and span.kind == "derived":
+                    for parent in span.parents:
+                        add_candidate(parent, cited_by=sid)
+                return
+            seen.add(sid)
+            materialized.append(span)
+
+        for sid in input_sids:
+            add_candidate(sid)
+
+        pack_spans: List[Dict[str, str]] = []
+        text_parts: List[str] = []
+        chars_used = 0
+        truncated = False
+        cap = max(500, int(max_chars or 12000))
+        for span in materialized:
+            block_prefix = f"[{span.sid}] "
+            block = block_prefix + span.text
+            if chars_used + len(block) > cap:
+                remaining = cap - chars_used - len(block_prefix) - len("\n...[TRUNCATED SPAN]")
+                if remaining <= 80:
+                    excluded.append({"sid": span.sid, "reason": "prompt_budget_exceeded"})
+                    truncated = True
+                    continue
+                span_text = span.text[:remaining].rstrip() + "\n...[TRUNCATED SPAN]"
+                block = block_prefix + span_text
+                truncated = True
+            else:
+                span_text = span.text
+            chars_used += len(block)
+            pack_spans.append({"sid": span.sid, "text": span_text})
+            text_parts.append(block)
+
+        text = "\n".join(text_parts).strip()
+        pack_basis = {
+            "run_id": run.run_id,
+            "input_sids": input_sids,
+            "materialized": [
+                {
+                    "sid": s.sid,
+                    "eid": s.eid,
+                    "text_sha256": s.text_sha256,
+                    "status": s.status,
+                    "kind": s.kind,
+                    "sensitivity": s.sensitivity,
+                }
+                for s in materialized
+                if any(ps["sid"] == s.sid for ps in pack_spans)
+            ],
+            "text_sha256": _sha256_text(text),
+            "max_chars": cap,
+        }
+        return {
+            "run_id": run.run_id,
+            "input_sids": input_sids,
+            "materialized_sids": [s["sid"] for s in pack_spans],
+            "excluded": excluded,
+            "spans": pack_spans,
+            "text": text,
+            "chars": len(text),
+            "text_sha256": _sha256_text(text),
+            "pack_id": _stable_json_hash(pack_basis),
+            "truncated": truncated,
+            "policy": {
+                "allowed_kinds": allowed,
+                "allow_sensitive": bool(allow_sensitive),
+                "include_stale": bool(include_stale),
+                "allow_untrusted": bool(allow_untrusted),
+                "include_derived_parents": bool(include_derived_parents),
+                "max_chars": cap,
+            },
+        }
+
+    def query_evidence(
+        self,
+        *,
+        run: RunState,
+        query: str,
+        limit: int = 10,
+        kinds: Optional[Sequence[str]] = None,
+        source_types: Optional[Sequence[str]] = None,
+        trust: Optional[Sequence[str]] = None,
+        status: Optional[Sequence[str]] = None,
+        include_derived: bool = False,
+        include_stale: bool = False,
+    ) -> List[Dict[str, Any]]:
+        tokens = [t for t in re.split(r"[^a-zA-Z0-9_]+", (query or "").lower()) if t]
+        if not tokens:
+            return []
+        kind_set = {str(k).strip().lower() for k in (kinds or []) if str(k).strip()}
+        source_set = {str(k).strip().lower() for k in (source_types or []) if str(k).strip()}
+        trust_set = {str(k).strip().lower() for k in (trust or []) if str(k).strip()}
+        status_set = {str(k).strip().lower() for k in (status or []) if str(k).strip()}
+
+        scored: List[tuple[float, SpanRecord, List[str]]] = []
+        for sid in run.span_order:
+            rec = run.spans[sid]
+            if rec.kind == "derived" and not include_derived:
+                continue
+            if rec.status != "active" and not include_stale:
+                continue
+            if kind_set and rec.kind not in kind_set:
+                continue
+            if source_set and rec.source_type not in source_set:
+                continue
+            if trust_set and rec.trust not in trust_set:
+                continue
+            if status_set and rec.status not in status_set:
+                continue
+            text_l = rec.text.lower()
+            matched = [tok for tok in tokens if tok in text_l]
+            if not matched:
+                continue
+            score = sum(text_l.count(tok) for tok in matched) + (0.1 * len(set(matched)))
+            scored.append((float(score), rec, matched))
+        scored.sort(key=lambda item: (-item[0], item[1].sid))
+        out: List[Dict[str, Any]] = []
+        for score, rec, matched in scored[: max(1, int(limit or 10))]:
+            item = rec.to_public_dict(include_text=False, preview_chars=220)
+            item.update({"score": score, "why_matched": matched})
+            out.append(item)
+        return out
 
     def set_microplan(
         self, *, run: RunState, steps: List[Dict[str, Any]], default_target: float = 0.8

--- a/src/berry/enforcement.py
+++ b/src/berry/enforcement.py
@@ -6,7 +6,7 @@ import re
 import secrets
 import time
 from dataclasses import dataclass, field, replace
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 
 class EnforcementError(Exception):
@@ -157,6 +157,63 @@ def _normalise_tags(tags: Optional[Iterable[str]]) -> List[str]:
         seen.add(tag)
         out.append(tag)
     return out
+
+
+def mark_run_dirty(
+    run: "RunState",
+    *,
+    all: bool = False,
+    meta: bool = False,
+    spans: Optional[Iterable[str]] = None,
+    attempts: Optional[Iterable[str]] = None,
+    claims: Optional[Iterable[str]] = None,
+    claim_links: Optional[Iterable[str]] = None,
+    audits: Optional[Iterable[str]] = None,
+) -> None:
+    """Mark ledger rows that must be durably re-committed.
+
+    The SQLite ledger persists hot writes incrementally.  RunStore mutation
+    methods call this helper so ``persist_run`` can avoid reserializing and
+    reinserting every child row on every span append.  Direct users that mutate
+    ``RunState`` fields outside RunStore should either call this helper or force
+    a full checkpoint through the ledger layer.
+    """
+
+    if all:
+        run.ledger_dirty_all = True
+        meta = True
+    if meta:
+        run.ledger_dirty_meta = True
+    for sid in spans or []:
+        value = str(sid or "").strip()
+        if value:
+            run.ledger_dirty_spans.add(value)
+    for attempt_id in attempts or []:
+        value = str(attempt_id or "").strip()
+        if value:
+            run.ledger_dirty_attempts.add(value)
+    for cid in claims or []:
+        value = str(cid or "").strip()
+        if value:
+            run.ledger_dirty_claims.add(value)
+    for link_id in claim_links or []:
+        value = str(link_id or "").strip()
+        if value:
+            run.ledger_dirty_claim_links.add(value)
+    for audit_id in audits or []:
+        value = str(audit_id or "").strip()
+        if value:
+            run.ledger_dirty_audits.add(value)
+
+
+def clear_run_dirty(run: "RunState") -> None:
+    run.ledger_dirty_all = False
+    run.ledger_dirty_meta = False
+    run.ledger_dirty_spans.clear()
+    run.ledger_dirty_attempts.clear()
+    run.ledger_dirty_claims.clear()
+    run.ledger_dirty_claim_links.clear()
+    run.ledger_dirty_audits.clear()
 
 
 @dataclass(frozen=True)
@@ -566,6 +623,21 @@ class RunState:
     # This is *not* evidence by itself, but it captures the user's goal.
     deliverable_sid: Optional[str] = None
 
+    # Incremental ledger bookkeeping. These fields are intentionally not serialized
+    # into run payloads; they describe what the in-memory object has changed since
+    # the last durable commit. Newly created runs start dirty so the first persist
+    # writes a full baseline event. Loaded runs are marked clean by the ledger.
+    ledger_dirty_all: bool = field(default=True, repr=False)
+    ledger_dirty_meta: bool = field(default=True, repr=False)
+    ledger_dirty_spans: Set[str] = field(default_factory=set, repr=False)
+    ledger_dirty_attempts: Set[str] = field(default_factory=set, repr=False)
+    ledger_dirty_claims: Set[str] = field(default_factory=set, repr=False)
+    ledger_dirty_claim_links: Set[str] = field(default_factory=set, repr=False)
+    ledger_dirty_audits: Set[str] = field(default_factory=set, repr=False)
+    ledger_committed_head_event_hash: str = field(default="", repr=False)
+    ledger_committed_run_meta_sha256: str = field(default="", repr=False)
+    ledger_committed_row_hashes: Dict[str, Dict[str, str]] = field(default_factory=dict, repr=False)
+
 
 class RunStore:
     def __init__(self):
@@ -632,6 +704,7 @@ class RunStore:
 
         # Classic: clear deliverable anchor.
         run.deliverable_sid = None
+        mark_run_dirty(run, all=True)
         return run
 
     def record_attempt(
@@ -689,6 +762,7 @@ class RunStore:
         )
         run.next_attempt_idx += 1
         run.attempts.append(rec)
+        mark_run_dirty(run, meta=True, attempts=[rec.attempt_id])
         return rec
 
     def list_attempts(self, *, run: RunState, limit: int = 200) -> List[Dict[str, Any]]:
@@ -759,6 +833,7 @@ class RunStore:
         )
         run.claims[rec.cid] = rec
         run.claim_order.append(rec.cid)
+        mark_run_dirty(run, meta=True, claims=[rec.cid])
         return rec
 
     def get_claim(self, *, run: RunState, cid: str) -> ClaimRecord:
@@ -808,6 +883,7 @@ class RunStore:
             meta=meta,
         )
         run.claims[rec.cid] = updated
+        mark_run_dirty(run, meta=True, claims=[rec.cid])
         return updated
 
     def list_claims(
@@ -887,6 +963,7 @@ class RunStore:
         )
         run.next_claim_link_idx += 1
         run.claim_evidence_links.append(link)
+        mark_run_dirty(run, meta=True, claim_links=[link.link_id])
         return link
 
     def list_claim_evidence(
@@ -973,6 +1050,7 @@ class RunStore:
         )
         run.next_audit_idx += 1
         run.audits.append(audit)
+        mark_run_dirty(run, meta=True, audits=[audit.audit_id])
         return audit
 
     def list_audits(
@@ -1104,6 +1182,7 @@ class RunStore:
         run.spans[sid] = rec
         run.span_order.append(sid)
         run.spans_version += 1
+        mark_run_dirty(run, meta=True, spans=[sid])
         return rec
 
     def list_spans(
@@ -1183,6 +1262,7 @@ class RunStore:
         )
         run.spans[rec.sid] = updated
         run.spans_version += 1
+        mark_run_dirty(run, meta=True, spans=[rec.sid])
         return updated
 
     def extract_span(

--- a/src/berry/installer.py
+++ b/src/berry/installer.py
@@ -1,0 +1,1276 @@
+from __future__ import annotations
+
+import json
+import os
+import platform as _platform
+import re
+import shlex
+import shutil
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from string import Template
+from typing import Callable, Iterable, Literal
+
+from . import __version__
+from .clients import McpServerSpec
+from .integration import _upsert_codex_toml
+from .mcp_env import load_mcp_env
+
+Scope = Literal["user", "project"]
+
+_BERRY_SECTION_START = "<!-- berry:install:start -->"
+_BERRY_SECTION_END = "<!-- berry:install:end -->"
+_SECTION_RE = re.compile(
+    rf"\n?{re.escape(_BERRY_SECTION_START)}\n.*?\n{re.escape(_BERRY_SECTION_END)}\n?",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class PlatformSpec:
+    """Declarative install target for one assistant platform.
+
+    Host-specific behavior lives in this table rather than in the CLI, so adding an
+    assistant is a data change unless it needs a custom file format.
+    """
+
+    key: str
+    display: str
+    aliases: tuple[str, ...] = ()
+    user_skill_path: str | None = None
+    project_skill_path: str | None = None
+    user_instruction_path: str | None = None
+    project_instruction_path: str | None = None
+    instruction_kind: str = "markdown"
+    hook_settings_path: str | None = None
+    mcp_client: str | None = None
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class InstallOptions:
+    platform: str = "auto"
+    scope: Scope = "user"
+    project_dir: Path | None = None
+    force: bool = False
+    dry_run: bool = False
+    berry_command: tuple[str, ...] | None = None
+    name: str = "berry"
+    install_hooks: bool = True
+    install_mcp: bool = True
+
+
+@dataclass(frozen=True)
+class InstallAction:
+    platform: str
+    scope: str
+    kind: str
+    path: str
+    status: str  # written | updated | unchanged | skipped | failed | dry-run
+    message: str = ""
+
+
+def _home() -> Path:
+    return Path(os.path.expanduser("~")).resolve()
+
+
+def _is_windows() -> bool:
+    return sys.platform == "win32" or _platform.system().lower() == "windows"
+
+
+def _template_context(
+    invocation: tuple[str, ...], *, name: str, platform_key: str
+) -> dict[str, str]:
+    berry_cli = shlex.join(invocation)
+    mcp_invocation = (*invocation, "mcp", "--server", "classic")
+    return {
+        "berry_cli": berry_cli,
+        "berry_command_json": json.dumps(invocation[0]),
+        "berry_args_json": json.dumps(list(invocation[1:])),
+        "berry_mcp_cli": shlex.join(mcp_invocation),
+        "berry_mcp_command_json": json.dumps(mcp_invocation[0]),
+        "berry_mcp_args_json": json.dumps(list(mcp_invocation[1:])),
+        "server_name": name,
+        "platform": platform_key,
+        "version": __version__,
+    }
+
+
+def _resolve_invocation(raw: str | None = None) -> tuple[str, ...]:
+    """Return the command tuple to embed in generated config.
+
+    Preference order:
+    1. explicit --berry-command, parsed as a shell command;
+    2. the frozen executable, for PyInstaller/pkg builds;
+    3. an absolute berry CLI discovered on PATH;
+    4. sys.executable -m berry, which is safe for editable/source installs.
+    """
+
+    if raw is not None and raw.strip():
+        parts = tuple(shlex.split(raw, posix=(os.name != "nt")))
+        if not parts:
+            raise ValueError("--berry-command parsed to an empty command")
+        return parts
+    if getattr(sys, "frozen", False):  # PyInstaller / single-file binary
+        return (str(Path(sys.executable).resolve()),)
+    found = shutil.which("berry")
+    if found:
+        return (str(Path(found).resolve()),)
+    return (str(Path(sys.executable).resolve()), "-m", "berry")
+
+
+def _mcp_spec(*, name: str, invocation: tuple[str, ...]) -> McpServerSpec:
+    return McpServerSpec(
+        name=name,
+        command=invocation[0],
+        args=[*invocation[1:], "mcp", "--server", "classic"],
+        env=load_mcp_env(),
+    )
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def _write_if_changed(
+    actions: list[InstallAction],
+    *,
+    platform_key: str,
+    scope: Scope,
+    kind: str,
+    path: Path,
+    content: str,
+    dry_run: bool,
+) -> None:
+    old = _read_text(path)
+    if old == content:
+        actions.append(
+            InstallAction(platform_key, scope, kind, str(path), "unchanged", "already current")
+        )
+        return
+    status = "written" if not path.exists() else "updated"
+    if dry_run:
+        actions.append(InstallAction(platform_key, scope, kind, str(path), "dry-run", status))
+        return
+    _atomic_write_text(path, content)
+    actions.append(InstallAction(platform_key, scope, kind, str(path), status, ""))
+
+
+def _render_template(template: str, context: dict[str, str]) -> str:
+    return Template(template).safe_substitute(context)
+
+
+def _wrap_section(body: str) -> str:
+    return f"{_BERRY_SECTION_START}\n{body.strip()}\n{_BERRY_SECTION_END}\n"
+
+
+def _upsert_markdown_section(
+    actions: list[InstallAction],
+    *,
+    platform_key: str,
+    scope: Scope,
+    path: Path,
+    section: str,
+    dry_run: bool,
+) -> None:
+    old = _read_text(path)
+    wrapped = _wrap_section(section)
+    start_count = old.count(_BERRY_SECTION_START)
+    end_count = old.count(_BERRY_SECTION_END)
+    if start_count != end_count:
+        actions.append(
+            InstallAction(
+                platform_key,
+                scope,
+                "instructions",
+                str(path),
+                "failed",
+                "malformed Berry section markers; repair the file or remove the partial section",
+            )
+        )
+        return
+    if start_count > 1:
+        actions.append(
+            InstallAction(
+                platform_key,
+                scope,
+                "instructions",
+                str(path),
+                "failed",
+                "multiple Berry-managed sections found; remove duplicates before reinstalling",
+            )
+        )
+        return
+    if _BERRY_SECTION_START in old or _BERRY_SECTION_END in old:
+        new = _SECTION_RE.sub("\n" + wrapped, old).strip() + "\n"
+    elif old.strip():
+        new = old.rstrip() + "\n\n" + wrapped
+    else:
+        new = wrapped
+    _write_if_changed(
+        actions,
+        platform_key=platform_key,
+        scope=scope,
+        kind="instructions",
+        path=path,
+        content=new,
+        dry_run=dry_run,
+    )
+
+
+def _load_json_file(path: Path, *, force: bool) -> tuple[dict, str | None]:
+    if not path.exists():
+        return {}, None
+    try:
+        raw = path.read_text(encoding="utf-8")
+        if not raw.strip():
+            return {}, None
+        loaded = json.loads(raw)
+        if isinstance(loaded, dict):
+            return loaded, None
+        if force:
+            return {}, None
+        return {}, "top-level JSON value is not an object"
+    except json.JSONDecodeError as exc:
+        if force:
+            return {}, None
+        return {}, f"invalid JSON: {exc}"
+    except OSError as exc:
+        return {}, str(exc)
+
+
+def _strip_json_comments(raw: str) -> str:
+    """Strip JSONC comments while preserving string contents."""
+
+    out: list[str] = []
+    in_string = False
+    escaped = False
+    line_comment = False
+    block_comment = False
+    i = 0
+    while i < len(raw):
+        ch = raw[i]
+        nxt = raw[i + 1] if i + 1 < len(raw) else ""
+        if line_comment:
+            if ch == "\n":
+                line_comment = False
+                out.append(ch)
+            i += 1
+            continue
+        if block_comment:
+            if ch == "*" and nxt == "/":
+                block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+        if in_string:
+            out.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            i += 1
+            continue
+        if ch == "/" and nxt == "/":
+            line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            block_comment = True
+            i += 2
+            continue
+        if ch == '"':
+            in_string = True
+        out.append(ch)
+        i += 1
+    return re.sub(r",(\s*[}\]])", r"\1", "".join(out))
+
+
+def _load_json_or_jsonc(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    raw = path.read_text(encoding="utf-8")
+    if path.suffix == ".jsonc":
+        raw = _strip_json_comments(raw)
+    loaded = json.loads(raw) if raw.strip() else {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _upsert_json(
+    actions: list[InstallAction],
+    *,
+    platform_key: str,
+    scope: Scope,
+    path: Path,
+    force: bool,
+    dry_run: bool,
+    mutate: Callable[[dict], None],
+    kind: str,
+) -> None:
+    payload, err = _load_json_file(path, force=force)
+    if err:
+        actions.append(InstallAction(platform_key, scope, kind, str(path), "failed", err))
+        return
+    old = _read_text(path)
+    mutate(payload)
+    new = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if old == new:
+        actions.append(
+            InstallAction(platform_key, scope, kind, str(path), "unchanged", "already current")
+        )
+        return
+    status = "written" if not path.exists() else "updated"
+    if dry_run:
+        actions.append(InstallAction(platform_key, scope, kind, str(path), "dry-run", status))
+        return
+    _atomic_write_text(path, new)
+    actions.append(InstallAction(platform_key, scope, kind, str(path), status, ""))
+
+
+def _server_payload(spec: McpServerSpec) -> dict[str, object]:
+    payload: dict[str, object] = {"command": spec.command, "args": spec.args}
+    if spec.env:
+        payload["env"] = spec.env
+    return payload
+
+
+def _upsert_mcp_json(
+    actions: list[InstallAction],
+    *,
+    platform_key: str,
+    scope: Scope,
+    path: Path,
+    spec: McpServerSpec,
+    force: bool,
+    dry_run: bool,
+    key: str = "mcpServers",
+) -> None:
+    def mutate(payload: dict) -> None:
+        servers = payload.get(key)
+        if not isinstance(servers, dict):
+            servers = {}
+        servers[spec.name] = _server_payload(spec)
+        payload[key] = servers
+
+    _upsert_json(
+        actions,
+        platform_key=platform_key,
+        scope=scope,
+        path=path,
+        force=force,
+        dry_run=dry_run,
+        mutate=mutate,
+        kind="mcp-config",
+    )
+
+
+def _vscode_user_mcp_path() -> Path:
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA")
+        if base:
+            return Path(base).expanduser().resolve() / "Code" / "User" / "mcp.json"
+        return _home() / "AppData" / "Roaming" / "Code" / "User" / "mcp.json"
+    if sys.platform == "darwin":
+        return _home() / "Library" / "Application Support" / "Code" / "User" / "mcp.json"
+    return _home() / ".config" / "Code" / "User" / "mcp.json"
+
+
+def _upsert_codex_features(path: Path, *, dry_run: bool) -> tuple[str, str]:
+    """Ensure [features].multi_agent = true without taking a TOML dependency."""
+
+    old = _read_text(path)
+    lines = old.splitlines()
+    out: list[str] = []
+    in_features = False
+    saw_features = False
+    wrote_multi_agent = False
+    changed = False
+
+    def maybe_insert_feature() -> None:
+        nonlocal wrote_multi_agent, changed
+        if saw_features and not wrote_multi_agent:
+            out.append("multi_agent = true")
+            wrote_multi_agent = True
+            changed = True
+
+    for line in lines:
+        stripped = line.strip()
+        section_match = re.match(r"^\[([^\]]+)\]\s*$", stripped)
+        if section_match:
+            if in_features:
+                maybe_insert_feature()
+            section = section_match.group(1).strip()
+            in_features = section == "features"
+            saw_features = saw_features or in_features
+            out.append(line)
+            continue
+        if in_features and re.match(r"^multi_agent\s*=", stripped):
+            if stripped != "multi_agent = true":
+                out.append("multi_agent = true")
+                changed = True
+            else:
+                out.append(line)
+            wrote_multi_agent = True
+            continue
+        out.append(line)
+    if in_features:
+        maybe_insert_feature()
+    if not saw_features:
+        if out and out[-1].strip():
+            out.append("")
+        out.append("[features]")
+        out.append("multi_agent = true")
+        changed = True
+    new = "\n".join(out).rstrip() + "\n"
+    if old == new:
+        return "unchanged", old
+    if dry_run:
+        return "dry-run", new
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_text(path, new)
+    return ("written" if not old else "updated"), new
+
+
+def _install_codex_toml(
+    actions: list[InstallAction],
+    *,
+    platform_key: str,
+    scope: Scope,
+    path: Path,
+    spec: McpServerSpec,
+    dry_run: bool,
+) -> None:
+    if dry_run:
+        actions.append(
+            InstallAction(
+                platform_key, scope, "mcp-config", str(path), "dry-run", "upsert berry MCP server"
+            )
+        )
+        actions.append(
+            InstallAction(
+                platform_key,
+                scope,
+                "features",
+                str(path),
+                "dry-run",
+                "ensure [features].multi_agent = true",
+            )
+        )
+        return
+    try:
+        before_exists = path.exists()
+        before = _read_text(path)
+        _upsert_codex_toml(path, spec)
+        after = _read_text(path)
+        if before == after:
+            status = "unchanged"
+            msg = "already current"
+        else:
+            status = "updated" if before_exists else "written"
+            msg = ""
+        actions.append(InstallAction(platform_key, scope, "mcp-config", str(path), status, msg))
+        feat_status, _ = _upsert_codex_features(path, dry_run=False)
+        actions.append(
+            InstallAction(
+                platform_key, scope, "features", str(path), feat_status, "multi_agent = true"
+            )
+        )
+    except Exception as exc:
+        actions.append(
+            InstallAction(platform_key, scope, "mcp-config", str(path), "failed", str(exc))
+        )
+
+
+def _hook_entry(context: dict[str, str], *, matcher: str) -> dict[str, object]:
+    message = (
+        "Berry evidence verifier is installed. Prefer Berry MCP tools for factual claims and "
+        f"verification. Embedded command: {context['berry_mcp_cli']}"
+    )
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": message,
+        }
+    }
+    command = "printf '%s\\n' " + shlex.quote(json.dumps(payload, separators=(",", ":")))
+    return {
+        "matcher": matcher,
+        "hooks": [
+            {
+                "type": "command",
+                "command": command,
+                "berryManaged": True,
+            }
+        ],
+    }
+
+
+def _install_pre_tool_use_hooks(
+    actions: list[InstallAction],
+    *,
+    platform_key: str,
+    scope: Scope,
+    path: Path,
+    context: dict[str, str],
+    force: bool,
+    dry_run: bool,
+) -> None:
+    def mutate(payload: dict) -> None:
+        hooks = payload.get("hooks")
+        if not isinstance(hooks, dict):
+            hooks = {}
+        pre = hooks.get("PreToolUse")
+        if not isinstance(pre, list):
+            pre = []
+
+        def is_berry_managed(hook: object) -> bool:
+            if not isinstance(hook, dict):
+                return False
+            if hook.get("berryManaged") is True:
+                return True
+            text = json.dumps(hook).lower()
+            return "berry evidence verifier" in text or "embedded command:" in text
+
+        kept = [h for h in pre if not is_berry_managed(h)]
+        kept.append(_hook_entry(context, matcher="Bash"))
+        kept.append(_hook_entry(context, matcher="Read|Glob"))
+        hooks["PreToolUse"] = kept
+        payload["hooks"] = hooks
+
+    _upsert_json(
+        actions,
+        platform_key=platform_key,
+        scope=scope,
+        path=path,
+        force=force,
+        dry_run=dry_run,
+        mutate=mutate,
+        kind="hooks",
+    )
+
+
+def _install_gemini_hook(
+    actions: list[InstallAction],
+    *,
+    platform_key: str,
+    scope: Scope,
+    path: Path,
+    context: dict[str, str],
+    force: bool,
+    dry_run: bool,
+) -> None:
+    message = (
+        "Berry evidence verifier is installed. For codebase questions and factual claims, "
+        f"use Berry MCP tools when available. Embedded command: {context['berry_mcp_cli']}"
+    )
+    hook = {
+        "matcher": "read_file|list_directory|search_file_content|glob",
+        "hooks": [
+            {
+                "type": "command",
+                "command": "printf '%s\\n' "
+                + shlex.quote(json.dumps({"decision": "allow", "additionalContext": message})),
+                "berryManaged": True,
+            }
+        ],
+    }
+
+    def mutate(payload: dict) -> None:
+        hooks = payload.get("hooks")
+        if not isinstance(hooks, dict):
+            hooks = {}
+        before = hooks.get("BeforeTool")
+        if not isinstance(before, list):
+            before = []
+
+        def is_berry_managed(hook: object) -> bool:
+            if not isinstance(hook, dict):
+                return False
+            if hook.get("berryManaged") is True:
+                return True
+            text = json.dumps(hook).lower()
+            return "berry evidence verifier" in text or "embedded command:" in text
+
+        before = [h for h in before if not is_berry_managed(h)]
+        before.append(hook)
+        hooks["BeforeTool"] = before
+        payload["hooks"] = hooks
+
+    _upsert_json(
+        actions,
+        platform_key=platform_key,
+        scope=scope,
+        path=path,
+        force=force,
+        dry_run=dry_run,
+        mutate=mutate,
+        kind="hooks",
+    )
+
+
+_GENERIC_SKILL_TEMPLATE = """# Berry evidence verifier
+
+Berry is a local MCP runtime and verifier for evidence-backed coding-agent work.
+
+## Use this skill when
+- The user asks for a factual answer about a repository, plan, design, bug, or generated code.
+- You need to cite gathered evidence or verify that claims are supported by evidence spans.
+- You are about to produce a plan or final answer that should not rely on unstated context.
+
+## Operating rules
+1. Prefer Berry MCP tools over free-form guessing.
+2. Treat Berry evidence spans as the source of truth for factual claims.
+3. When Berry returns `state=need_grant`, show the requested scopes and wait for explicit user approval before calling `berry_approve`.
+4. When Berry returns `state=ask_user`, ask the returned questions verbatim and retry with the same `run_id` after the user answers.
+5. When Berry returns `state=done`, use the verified answer or plan.
+6. If the MCP server is unavailable, ask the user to run `$berry_mcp_cli` or reload MCP servers.
+
+## Embedded command
+- Berry CLI: `$berry_cli`
+- Berry MCP: `$berry_mcp_cli`
+
+Re-run `berry install` after moving/upgrading Berry, pipx, uv, or Python so generated configs refresh the embedded path.
+"""
+
+_ALWAYS_ON_TEMPLATE = """## Berry evidence verifier
+
+Berry is installed for this project/platform.
+
+- Use Berry MCP tools for evidence gathering and verification before making factual claims.
+- Prefer `berry_solve` for questions and `berry_change` for code-change planning.
+- Respect Berry's state machine: `need_grant` requires user approval, `ask_user` requires asking the returned questions, and `done` contains the verified output.
+- Embedded Berry MCP command: `$berry_mcp_cli`.
+- If Berry stops launching after an upgrade or environment move, re-run `berry install --platform $platform` to refresh this embedded path.
+"""
+
+_CURSOR_RULE_TEMPLATE = """---
+description: Berry evidence verifier context
+alwaysApply: true
+---
+
+Berry is installed for this workspace.
+
+- For factual claims, repository questions, and code-change plans, use Berry MCP tools before answering.
+- Prefer `berry_solve` for questions and `berry_change` for planned changes.
+- Follow Berry's state machine exactly: ask the user for grants/questions when Berry requests it.
+- Embedded Berry MCP command: `$berry_mcp_cli`.
+- Re-run `berry install --platform cursor` after moving/upgrading Berry to refresh this path.
+"""
+
+_KILO_PLUGIN_TEMPLATE = """// Berry Kilo plugin. Generated by `berry install --platform kilo`.
+// Fails open: if anything goes wrong, the user's tool call proceeds.
+export const BerryPlugin = async () => {
+  let reminded = false;
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (reminded) return;
+      if (input && input.tool === "bash") {
+        output.args.command = 'echo "[berry] Evidence verifier installed. Prefer Berry MCP tools for factual claims. Embedded MCP: $berry_mcp_cli" && ' + output.args.command;
+        reminded = true;
+      }
+    },
+  };
+};
+"""
+
+_ANTIGRAVITY_WORKFLOW_TEMPLATE = """---
+name: berry
+description: Use Berry to gather evidence and verify factual claims
+---
+
+# Workflow: Berry evidence verification
+
+Use the Berry skill and MCP tools for evidence-backed answers and code-change plans.
+
+Embedded MCP command: `$berry_mcp_cli`
+
+Re-run `berry install --platform antigravity` after moving/upgrading Berry to refresh this path.
+"""
+
+_KILO_COMMAND_TEMPLATE = """# /berry
+
+Use Berry for evidence-backed answers and verification.
+
+Embedded MCP command: `$berry_mcp_cli`
+"""
+
+_PLATFORM_CONFIG: dict[str, PlatformSpec] = {
+    "claude": PlatformSpec(
+        key="claude",
+        display="Claude Code",
+        aliases=("claude-code",),
+        user_skill_path="~/.claude/skills/berry/SKILL.md",
+        project_skill_path=".claude/skills/berry/SKILL.md",
+        user_instruction_path="~/.claude/CLAUDE.md",
+        project_instruction_path=".claude/CLAUDE.md",
+        hook_settings_path=".claude/settings.json",
+        mcp_client="claude",
+    ),
+    "windows": PlatformSpec(
+        key="windows",
+        display="Claude Code (Windows)",
+        aliases=("claude-windows", "win"),
+        user_skill_path="~/.claude/skills/berry/SKILL.md",
+        project_skill_path=".claude/skills/berry/SKILL.md",
+        user_instruction_path="~/.claude/CLAUDE.md",
+        project_instruction_path=".claude/CLAUDE.md",
+        hook_settings_path=".claude/settings.json",
+        mcp_client="claude",
+    ),
+    "codebuddy": PlatformSpec(
+        key="codebuddy",
+        display="CodeBuddy",
+        user_skill_path="~/.codebuddy/skills/berry/SKILL.md",
+        project_skill_path=".codebuddy/skills/berry/SKILL.md",
+        user_instruction_path="~/.codebuddy/CODEBUDDY.md",
+        project_instruction_path="CODEBUDDY.md",
+        hook_settings_path=".codebuddy/settings.json",
+        notes=("Uses Claude-style PreToolUse hooks where available.",),
+    ),
+    "codex": PlatformSpec(
+        key="codex",
+        display="Codex",
+        user_skill_path="~/.codex/skills/berry/SKILL.md",
+        project_skill_path=".codex/skills/berry/SKILL.md",
+        user_instruction_path="~/.codex/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+        mcp_client="codex",
+        notes=("Enables [features].multi_agent = true in config.toml.",),
+    ),
+    "opencode": PlatformSpec(
+        key="opencode",
+        display="OpenCode",
+        aliases=("open-code",),
+        user_skill_path="~/.config/opencode/skills/berry/SKILL.md",
+        project_skill_path=".opencode/skills/berry/SKILL.md",
+        user_instruction_path="~/.config/opencode/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+    ),
+    "kilo": PlatformSpec(
+        key="kilo",
+        display="Kilo Code",
+        aliases=("kilo-code",),
+        user_skill_path="~/.config/kilo/skills/berry/SKILL.md",
+        project_skill_path=".kilo/skills/berry/SKILL.md",
+        user_instruction_path="~/.config/kilo/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+        notes=("Also writes a native Kilo command and project plugin when project scoped.",),
+    ),
+    "copilot": PlatformSpec(
+        key="copilot",
+        display="GitHub Copilot CLI",
+        aliases=("github-copilot",),
+        user_skill_path="~/.copilot/skills/berry/SKILL.md",
+        project_skill_path=".copilot/skills/berry/SKILL.md",
+        user_instruction_path="~/.copilot/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+    ),
+    "vscode": PlatformSpec(
+        key="vscode",
+        display="VS Code Copilot Chat",
+        aliases=("vs-code", "copilot-chat"),
+        user_skill_path="~/.copilot/skills/berry/SKILL.md",
+        project_skill_path=".copilot/skills/berry/SKILL.md",
+        project_instruction_path=".github/copilot-instructions.md",
+        mcp_client="vscode",
+    ),
+    "aider": PlatformSpec(
+        key="aider",
+        display="Aider",
+        user_skill_path="~/.aider/skills/berry/SKILL.md",
+        project_skill_path=".aider/skills/berry/SKILL.md",
+        user_instruction_path="~/.aider/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+        notes=("Sequential agent extraction/verification guidance only; no hook is installed.",),
+    ),
+    "claw": PlatformSpec(
+        key="claw",
+        display="OpenClaw",
+        aliases=("openclaw",),
+        user_skill_path="~/.openclaw/skills/berry/SKILL.md",
+        project_skill_path=".openclaw/skills/berry/SKILL.md",
+        user_instruction_path="~/.openclaw/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+    ),
+    "droid": PlatformSpec(
+        key="droid",
+        display="Factory Droid",
+        aliases=("factory", "factory-droid"),
+        user_skill_path="~/.factory/skills/berry/SKILL.md",
+        project_skill_path=".factory/skills/berry/SKILL.md",
+        user_instruction_path="~/.factory/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+        notes=("Guidance mentions Task-style parallel dispatch where the host supports it.",),
+    ),
+    "trae": PlatformSpec(
+        key="trae",
+        display="Trae",
+        user_skill_path="~/.trae/skills/berry/SKILL.md",
+        project_skill_path=".trae/skills/berry/SKILL.md",
+        user_instruction_path="~/.trae/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+        notes=("Trae does not support PreToolUse hooks; AGENTS.md is the always-on path.",),
+    ),
+    "trae-cn": PlatformSpec(
+        key="trae-cn",
+        display="Trae CN",
+        aliases=("traecn",),
+        user_skill_path="~/.trae-cn/skills/berry/SKILL.md",
+        project_skill_path=".trae-cn/skills/berry/SKILL.md",
+        user_instruction_path="~/.trae-cn/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+        notes=("Trae CN uses the same always-on guidance as Trae.",),
+    ),
+    "gemini": PlatformSpec(
+        key="gemini",
+        display="Gemini CLI",
+        user_skill_path="~/.gemini/skills/berry/SKILL.md",
+        project_skill_path=".gemini/skills/berry/SKILL.md",
+        user_instruction_path="~/.gemini/GEMINI.md",
+        project_instruction_path="GEMINI.md",
+        hook_settings_path=".gemini/settings.json",
+        mcp_client="gemini",
+    ),
+    "hermes": PlatformSpec(
+        key="hermes",
+        display="Hermes",
+        user_skill_path="~/.hermes/skills/berry/SKILL.md",
+        project_skill_path=".hermes/skills/berry/SKILL.md",
+        user_instruction_path="~/.hermes/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+    ),
+    "kimi": PlatformSpec(
+        key="kimi",
+        display="Kimi Code",
+        aliases=("kimi-code",),
+        user_skill_path="~/.kimi/skills/berry/SKILL.md",
+        project_skill_path=".kimi/skills/berry/SKILL.md",
+        user_instruction_path="~/.kimi/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+    ),
+    "amp": PlatformSpec(
+        key="amp",
+        display="Amp",
+        user_skill_path="~/.config/agents/skills/berry/SKILL.md",
+        project_skill_path=".agents/skills/berry/SKILL.md",
+        user_instruction_path="~/.config/agents/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+    ),
+    "kiro": PlatformSpec(
+        key="kiro",
+        display="Kiro IDE/CLI",
+        user_skill_path="~/.kiro/skills/berry/SKILL.md",
+        project_skill_path=".kiro/skills/berry/SKILL.md",
+        user_instruction_path="~/.kiro/steering/berry.md",
+        project_instruction_path=".kiro/steering/berry.md",
+        notes=("Writes Kiro steering guidance.",),
+    ),
+    "pi": PlatformSpec(
+        key="pi",
+        display="Pi coding agent",
+        user_skill_path="~/.pi/agent/skills/berry/SKILL.md",
+        project_skill_path=".pi/agent/skills/berry/SKILL.md",
+        user_instruction_path="~/.pi/agent/AGENTS.md",
+        project_instruction_path="AGENTS.md",
+    ),
+    "cursor": PlatformSpec(
+        key="cursor",
+        display="Cursor",
+        project_instruction_path=".cursor/rules/berry.mdc",
+        instruction_kind="cursor-rule",
+        mcp_client="cursor",
+        notes=("Cursor consumes the alwaysApply rule; no separate skill file is required.",),
+    ),
+    "devin": PlatformSpec(
+        key="devin",
+        display="Devin CLI",
+        user_skill_path="~/.config/devin/skills/berry/SKILL.md",
+        project_skill_path=".devin/skills/berry/SKILL.md",
+        user_instruction_path="~/.config/devin/AGENTS.md",
+        project_instruction_path=".windsurf/rules/berry.md",
+    ),
+    "antigravity": PlatformSpec(
+        key="antigravity",
+        display="Google Antigravity",
+        aliases=("google-antigravity",),
+        user_skill_path="~/.gemini/config/skills/berry/SKILL.md",
+        project_skill_path=".agents/skills/berry/SKILL.md",
+        user_instruction_path="~/.gemini/antigravity/AGENTS.md",
+        project_instruction_path=".agents/rules/berry.md",
+        mcp_client="gemini",
+        notes=("Also writes a project workflow file under .agents/workflows/.",),
+    ),
+}
+
+_ALIAS_TO_KEY: dict[str, str] = {}
+for _key, _spec in _PLATFORM_CONFIG.items():
+    _ALIAS_TO_KEY[_key] = _key
+    for _alias in _spec.aliases:
+        _ALIAS_TO_KEY[_alias] = _key
+
+
+def platform_keys() -> tuple[str, ...]:
+    return tuple(_PLATFORM_CONFIG.keys())
+
+
+def resolve_platform(raw: str | None) -> str:
+    s = (raw or "auto").strip().lower()
+    if s == "auto":
+        return "windows" if _is_windows() else "claude"
+    key = _ALIAS_TO_KEY.get(s)
+    if not key:
+        raise ValueError(f"unknown platform {raw!r}; choose one of: {', '.join(platform_keys())}")
+    return key
+
+
+def _path(raw: str, *, scope: Scope, project_dir: Path) -> Path:
+    if raw.startswith("~/") or raw == "~":
+        return Path(os.path.expanduser(raw)).resolve()
+    base = project_dir if scope == "project" else _home()
+    return (base / raw).resolve()
+
+
+def _skill_path(spec: PlatformSpec, *, scope: Scope, project_dir: Path) -> Path | None:
+    raw = spec.project_skill_path if scope == "project" else spec.user_skill_path
+    if not raw:
+        return None
+    return _path(raw, scope=scope, project_dir=project_dir)
+
+
+def _instruction_path(spec: PlatformSpec, *, scope: Scope, project_dir: Path) -> Path | None:
+    raw = spec.project_instruction_path if scope == "project" else spec.user_instruction_path
+    if not raw:
+        # Some platforms (e.g. VS Code/Cursor) are project-instruction only. If
+        # a user-scope install is requested, still write the project rule in cwd
+        # because that is the only host-supported always-on surface.
+        raw = spec.project_instruction_path
+        scope = "project"
+    if not raw:
+        return None
+    return _path(raw, scope=scope, project_dir=project_dir)
+
+
+def _settings_path(spec: PlatformSpec, *, project_dir: Path) -> Path | None:
+    if not spec.hook_settings_path:
+        return None
+    # Hooks are workspace settings for these hosts. Even for user-scope installs,
+    # writing hooks globally would be surprising, so keep them project-scoped.
+    return (project_dir / spec.hook_settings_path).resolve()
+
+
+def _render_skill(context: dict[str, str]) -> str:
+    return _render_template(_GENERIC_SKILL_TEMPLATE, context)
+
+
+def _render_instructions(spec: PlatformSpec, context: dict[str, str]) -> str:
+    if spec.instruction_kind == "cursor-rule":
+        return _render_template(_CURSOR_RULE_TEMPLATE, context)
+    extra = ""
+    if spec.key == "codex":
+        extra = "\n- Codex users: `[features].multi_agent = true` is installed in config.toml for parallel agent work.\n"
+    elif spec.key == "droid":
+        extra = "\n- When Factory Droid exposes Task-style subagents, dispatch independent verification/extraction work in parallel.\n"
+    elif spec.key in {"aider", "claw"}:
+        extra = "\n- This host currently gets sequential always-on guidance; no PreToolUse hook is installed.\n"
+    elif spec.key in {"trae", "trae-cn"}:
+        extra = "\n- Trae does not expose PreToolUse hooks here; this AGENTS.md section is the always-on mechanism.\n"
+    return _render_template(_ALWAYS_ON_TEMPLATE + extra, context)
+
+
+def _install_extra_platform_files(
+    actions: list[InstallAction],
+    *,
+    spec: PlatformSpec,
+    scope: Scope,
+    project_dir: Path,
+    context: dict[str, str],
+    dry_run: bool,
+) -> None:
+    if spec.key == "kilo":
+        command_path = (
+            _path("~/.config/kilo/command/berry.md", scope="user", project_dir=project_dir)
+            if scope == "user"
+            else (project_dir / ".kilo" / "command" / "berry.md").resolve()
+        )
+        _write_if_changed(
+            actions,
+            platform_key=spec.key,
+            scope=scope,
+            kind="command",
+            path=command_path,
+            content=_render_template(_KILO_COMMAND_TEMPLATE, context),
+            dry_run=dry_run,
+        )
+        if scope == "project":
+            plugin_path = (project_dir / ".kilo" / "plugins" / "berry.js").resolve()
+            _write_if_changed(
+                actions,
+                platform_key=spec.key,
+                scope=scope,
+                kind="plugin",
+                path=plugin_path,
+                content=_render_template(_KILO_PLUGIN_TEMPLATE, context),
+                dry_run=dry_run,
+            )
+            json_path = (project_dir / ".kilo" / "kilo.json").resolve()
+            jsonc_path = (project_dir / ".kilo" / "kilo.jsonc").resolve()
+            read_path = json_path if json_path.exists() else jsonc_path
+            try:
+                config = _load_json_or_jsonc(read_path)
+                plugins = config.get("plugin")
+                if not isinstance(plugins, list):
+                    plugins = []
+                config["plugin"] = plugins
+                entry = plugin_path.as_uri()
+                if entry not in plugins:
+                    plugins.append(entry)
+                new = json.dumps(config, indent=2, sort_keys=True) + "\n"
+                _write_if_changed(
+                    actions,
+                    platform_key=spec.key,
+                    scope=scope,
+                    kind="plugin-config",
+                    path=json_path,
+                    content=new,
+                    dry_run=dry_run,
+                )
+            except Exception as exc:
+                actions.append(
+                    InstallAction(
+                        spec.key,
+                        scope,
+                        "plugin-config",
+                        str(json_path),
+                        "failed",
+                        str(exc),
+                    )
+                )
+    elif spec.key == "antigravity":
+        workflow_path = (project_dir / ".agents" / "workflows" / "berry.md").resolve()
+        _write_if_changed(
+            actions,
+            platform_key=spec.key,
+            scope=scope,
+            kind="workflow",
+            path=workflow_path,
+            content=_render_template(_ANTIGRAVITY_WORKFLOW_TEMPLATE, context),
+            dry_run=dry_run,
+        )
+
+
+def install_platform(options: InstallOptions) -> list[InstallAction]:
+    platform_key = resolve_platform(options.platform)
+    spec = _PLATFORM_CONFIG[platform_key]
+    project_dir = (options.project_dir or Path.cwd()).expanduser().resolve()
+    invocation = options.berry_command or _resolve_invocation(None)
+    context = _template_context(invocation, name=options.name, platform_key=platform_key)
+    actions: list[InstallAction] = []
+
+    skill_path = _skill_path(spec, scope=options.scope, project_dir=project_dir)
+    if skill_path is not None:
+        _write_if_changed(
+            actions,
+            platform_key=platform_key,
+            scope=options.scope,
+            kind="skill",
+            path=skill_path,
+            content=_render_skill(context),
+            dry_run=options.dry_run,
+        )
+    else:
+        actions.append(
+            InstallAction(
+                platform_key, options.scope, "skill", "", "skipped", "platform has no skill file"
+            )
+        )
+
+    inst_path = _instruction_path(spec, scope=options.scope, project_dir=project_dir)
+    if inst_path is not None:
+        _upsert_markdown_section(
+            actions,
+            platform_key=platform_key,
+            scope=options.scope,
+            path=inst_path,
+            section=_render_instructions(spec, context),
+            dry_run=options.dry_run,
+        )
+
+    if options.install_hooks:
+        settings_path = _settings_path(spec, project_dir=project_dir)
+        if settings_path is not None:
+            if platform_key == "gemini":
+                _install_gemini_hook(
+                    actions,
+                    platform_key=platform_key,
+                    scope=options.scope,
+                    path=settings_path,
+                    context=context,
+                    force=options.force,
+                    dry_run=options.dry_run,
+                )
+            else:
+                _install_pre_tool_use_hooks(
+                    actions,
+                    platform_key=platform_key,
+                    scope=options.scope,
+                    path=settings_path,
+                    context=context,
+                    force=options.force,
+                    dry_run=options.dry_run,
+                )
+
+    if options.install_mcp and spec.mcp_client:
+        spec_obj = _mcp_spec(name=options.name, invocation=invocation)
+        if spec.mcp_client == "codex":
+            path = _path(
+                "~/.codex/config.toml" if options.scope == "user" else ".codex/config.toml",
+                scope=options.scope,
+                project_dir=project_dir,
+            )
+            _install_codex_toml(
+                actions,
+                platform_key=platform_key,
+                scope=options.scope,
+                path=path,
+                spec=spec_obj,
+                dry_run=options.dry_run,
+            )
+        elif spec.mcp_client == "claude":
+            path = (
+                _path("~/.claude.json", scope="user", project_dir=project_dir)
+                if options.scope == "user"
+                else (project_dir / ".mcp.json").resolve()
+            )
+            _upsert_mcp_json(
+                actions,
+                platform_key=platform_key,
+                scope=options.scope,
+                path=path,
+                spec=spec_obj,
+                force=options.force,
+                dry_run=options.dry_run,
+            )
+        elif spec.mcp_client == "gemini":
+            path = _path(
+                "~/.gemini/settings.json" if options.scope == "user" else ".gemini/settings.json",
+                scope=options.scope,
+                project_dir=project_dir,
+            )
+            _upsert_mcp_json(
+                actions,
+                platform_key=platform_key,
+                scope=options.scope,
+                path=path,
+                spec=spec_obj,
+                force=options.force,
+                dry_run=options.dry_run,
+            )
+        elif spec.mcp_client == "cursor":
+            path = _path(
+                "~/.cursor/mcp.json" if options.scope == "user" else ".cursor/mcp.json",
+                scope=options.scope,
+                project_dir=project_dir,
+            )
+            _upsert_mcp_json(
+                actions,
+                platform_key=platform_key,
+                scope=options.scope,
+                path=path,
+                spec=spec_obj,
+                force=options.force,
+                dry_run=options.dry_run,
+            )
+        elif spec.mcp_client == "vscode":
+            path = (
+                _vscode_user_mcp_path()
+                if options.scope == "user"
+                else (project_dir / ".vscode" / "mcp.json").resolve()
+            )
+            _upsert_mcp_json(
+                actions,
+                platform_key=platform_key,
+                scope=options.scope,
+                path=path,
+                spec=spec_obj,
+                force=options.force,
+                dry_run=options.dry_run,
+                key="servers",
+            )
+
+    _install_extra_platform_files(
+        actions,
+        spec=spec,
+        scope=options.scope,
+        project_dir=project_dir,
+        context=context,
+        dry_run=options.dry_run,
+    )
+
+    return actions
+
+
+def install_many(
+    platforms: Iterable[str],
+    *,
+    scope: Scope,
+    project_dir: Path | None,
+    force: bool,
+    dry_run: bool,
+    berry_command_raw: str | None,
+    name: str,
+    install_hooks: bool,
+    install_mcp: bool,
+) -> list[InstallAction]:
+    invocation = _resolve_invocation(berry_command_raw)
+    all_actions: list[InstallAction] = []
+    for platform in platforms:
+        all_actions.extend(
+            install_platform(
+                InstallOptions(
+                    platform=platform,
+                    scope=scope,
+                    project_dir=project_dir,
+                    force=force,
+                    dry_run=dry_run,
+                    berry_command=invocation,
+                    name=name,
+                    install_hooks=install_hooks,
+                    install_mcp=install_mcp,
+                )
+            )
+        )
+    return all_actions
+
+
+def actions_to_json(actions: Iterable[InstallAction]) -> str:
+    return json.dumps([asdict(a) for a in actions], indent=2, sort_keys=True) + "\n"
+
+
+def format_actions(actions: Iterable[InstallAction]) -> str:
+    lines: list[str] = []
+    for action in actions:
+        path = f" -> {action.path}" if action.path else ""
+        msg = f" ({action.message})" if action.message else ""
+        lines.append(f"{action.platform}: {action.kind}: {action.status}{path}{msg}")
+    return "\n".join(lines) + ("\n" if lines else "")

--- a/src/berry/integration.py
+++ b/src/berry/integration.py
@@ -66,8 +66,12 @@ def _upsert_codex_toml(path: Path, spec: McpServerSpec) -> None:
 
     import re
 
+    # Remove only Berry's own MCP sections. The previous pattern stopped only
+    # at the next [mcp_servers.*] section, which could accidentally consume
+    # unrelated TOML sections (for example [features]) that followed Berry's
+    # block. Stop at any next TOML section instead.
     pat = re.compile(
-        rf"^\[mcp_servers\.{re.escape(spec.name)}(?:\.env)?\]\n(?:.*\n)*?(?=^\[mcp_servers\.|\Z)",
+        rf"^\[mcp_servers\.{re.escape(spec.name)}(?:\.env)?\]\s*\n(?:.*\n)*?(?=^\[|\Z)",
         re.M,
     )
     new_text = pat.sub("", text).rstrip()

--- a/src/berry/mcp_server.py
+++ b/src/berry/mcp_server.py
@@ -13,9 +13,23 @@ Approved MCP tools only:
 - record_attempt
 - list_attempts
 - distill_span
+- extract_span
+- mark_span
 - list_spans
 - get_span
 - search_spans
+- query_evidence
+- get_evidence_pack
+- create_claim
+- link_claim_evidence
+- list_claim_evidence
+- list_claims
+- get_claim
+- mark_claim
+- audit_claims
+- list_audits
+- detect_hallucination_run
+- audit_trace_budget_run
 
 All other tools (web, exec, repo ops, grants, microplans, verified writes, health/status, etc.)
 are intentionally not registered.
@@ -26,16 +40,18 @@ from __future__ import annotations
 import argparse
 import contextlib
 import csv
+import hashlib
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from .config import load_config
-from .enforcement import AttemptRecord, EnforcementError, RunState, RunStore, SpanRecord
+from .enforcement import EnforcementError, RunState, RunStore, SpanRecord
 from .hallucination_detector.core import (
     run_audit_trace_budget,
     run_detect_hallucination,
@@ -44,6 +60,17 @@ from .mcp_env import load_mcp_env
 from .paths import ensure_berry_home, resolve_user_path
 from .permissions import can_read_path
 from .prompts import list_prompts
+from .run_ledger import (
+    atomic_write_text as _ledger_atomic_write_text,
+    attempts_tsv_path as _ledger_attempts_tsv_path,
+    evidence_tsv_path as _ledger_evidence_tsv_path,
+    load_persisted_run as _ledger_load_persisted_run,
+    persist_run as _ledger_persist_run,
+    run_dir as _ledger_run_dir,
+    run_json_path as _ledger_run_json_path,
+    run_sqlite_path as _ledger_run_sqlite_path,
+    span_to_payload as _ledger_span_to_payload,
+)
 
 
 @contextlib.contextmanager
@@ -64,202 +91,266 @@ def _runs_dir() -> Path:
 
 
 def _run_dir(run_id: str) -> Path:
-    d = _runs_dir() / str(run_id)
-    d.mkdir(parents=True, exist_ok=True)
-    return d
+    return _ledger_run_dir(str(run_id))
 
 
 def _run_json_path(run_id: str) -> Path:
-    return _run_dir(run_id) / "run.json"
+    return _ledger_run_json_path(run_id)
+
+
+def _run_sqlite_path(run_id: str) -> Path:
+    return _ledger_run_sqlite_path(run_id)
 
 
 def _evidence_tsv_path(run_id: str) -> Path:
-    return _run_dir(run_id) / "evidence.tsv"
+    return _ledger_evidence_tsv_path(run_id)
 
 
 def _attempts_tsv_path(run_id: str) -> Path:
-    return _run_dir(run_id) / "attempts.tsv"
+    return _ledger_attempts_tsv_path(run_id)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    _ledger_atomic_write_text(path, text)
+
+
+def _span_to_payload(rec: SpanRecord) -> Dict[str, Any]:
+    return _ledger_span_to_payload(rec)
+
+
+def _git_output(project_root: Optional[Path], args: List[str]) -> str:
+    if not project_root:
+        return ""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(project_root),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+    except Exception:
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _git_bytes(project_root: Optional[Path], args: List[str]) -> Optional[bytes]:
+    """Return exact git object bytes, preserving whitespace and empty files."""
+
+    if not project_root:
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(project_root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    return bytes(proc.stdout or b"")
+
+
+def _capture_git_baseline(project_root: Optional[Path]) -> Tuple[str, Optional[str]]:
+    commit = _git_output(project_root, ["rev-parse", "--verify", "HEAD"])
+    if commit:
+        return "git", commit
+    return "fs", None
+
+
+def _rel_path(path: Path, project_root: Optional[Path]) -> str:
+    if project_root:
+        try:
+            return str(path.resolve().relative_to(project_root.resolve()))
+        except Exception:
+            pass
+    return str(path)
+
+
+def _file_sha256(path: Path) -> str:
+    import hashlib
+
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _decode_bytes(raw: bytes) -> Tuple[str, str]:
+    try:
+        return raw.decode("utf-8"), "utf-8"
+    except UnicodeDecodeError:
+        return raw.decode("latin-1"), "latin-1"
+
+
+def _line_byte_offsets(raw: bytes) -> List[int]:
+    offsets = [0]
+    for i, b in enumerate(raw):
+        if b == 10:  # \n
+            offsets.append(i + 1)
+    offsets.append(len(raw))
+    return offsets
+
+
+def _extract_cited_sids(text: str) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for m in re.finditer(r"\[(S\d+)\]", str(text or "")):
+        sid = m.group(1)
+        if sid not in seen:
+            seen.add(sid)
+            out.append(sid)
+    return out
+
+
+def _collect_step_cites(steps: List[Dict[str, Any]]) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for st in steps or []:
+        if not isinstance(st, dict):
+            continue
+        for raw in st.get("cites") or []:
+            sid = str(raw or "").strip()
+            if sid and sid not in seen:
+                seen.add(sid)
+                out.append(sid)
+    return out
+
+
+def _fail_closed_report(*, error: str, pack: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    return {
+        "flagged": True,
+        "under_budget": True,
+        "error": str(error),
+        "summary": {"evidence_pack": pack or {}, "fail_closed": True},
+        "details": [],
+    }
 
 
 def _write_evidence_tsv(run: RunState) -> None:
-    with _evidence_tsv_path(run.run_id).open("w", encoding="utf-8", newline="") as fh:
-        writer = csv.writer(fh, delimiter="\t")
-        writer.writerow(["ts", "run_id", "sid", "source", "kind", "locator", "chars", "preview"])
-        for sid in run.span_order:
-            rec = run.spans[sid]
-            meta = dict(rec.meta or {})
-            locator = ""
-            if meta.get("path"):
-                locator = (
-                    f"{meta.get('path')}:{meta.get('start_line', '')}-{meta.get('end_line', '')}"
-                )
+    path = _evidence_tsv_path(run.run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{time.time_ns()}")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh, delimiter="\t")
             writer.writerow(
                 [
-                    f"{float(rec.created_at):.6f}",
-                    run.run_id,
-                    rec.sid,
-                    rec.source,
-                    str(meta.get("kind") or ""),
-                    locator,
-                    len(rec.text),
-                    rec.text.strip().replace("\n", " ")[:200],
+                    "ts",
+                    "run_id",
+                    "sid",
+                    "eid",
+                    "source",
+                    "source_type",
+                    "kind",
+                    "trust",
+                    "status",
+                    "sensitivity",
+                    "locator",
+                    "parents",
+                    "text_sha256",
+                    "chars",
+                    "preview",
                 ]
             )
+            for sid in run.span_order:
+                rec = run.spans[sid]
+                locator = ""
+                if rec.locator:
+                    path_val = rec.locator.get("path") or rec.locator.get("rel_path") or ""
+                    start = rec.locator.get("start_line", "")
+                    end = rec.locator.get("end_line", "")
+                    locator = f"{path_val}:{start}-{end}" if path_val else json.dumps(rec.locator)
+                writer.writerow(
+                    [
+                        f"{float(rec.created_at):.6f}",
+                        run.run_id,
+                        rec.sid,
+                        rec.eid,
+                        rec.source,
+                        rec.source_type,
+                        rec.kind,
+                        rec.trust,
+                        rec.status,
+                        rec.sensitivity,
+                        locator,
+                        ",".join(rec.parents),
+                        rec.text_sha256,
+                        len(rec.text),
+                        rec.preview(limit=200, redact_sensitive=True),
+                    ]
+                )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def _write_attempts_tsv(run: RunState) -> None:
-    with _attempts_tsv_path(run.run_id).open("w", encoding="utf-8", newline="") as fh:
-        writer = csv.writer(fh, delimiter="\t")
-        writer.writerow(
-            [
-                "ts",
-                "run_id",
-                "attempt_id",
-                "claim_id",
-                "hypothesis",
-                "action",
-                "budget_minutes",
-                "input_sids",
-                "output_sids",
-                "audit_status",
-                "decision",
-                "next_step",
-            ]
-        )
-        for rec in run.attempts:
+    path = _attempts_tsv_path(run.run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{time.time_ns()}")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh, delimiter="\t")
             writer.writerow(
                 [
-                    f"{float(rec.created_at):.6f}",
-                    run.run_id,
-                    rec.attempt_id,
-                    rec.claim_id,
-                    rec.hypothesis,
-                    rec.action,
-                    f"{float(rec.budget_minutes):.2f}",
-                    ",".join(rec.input_sids),
-                    ",".join(rec.output_sids),
-                    rec.audit_status,
-                    rec.decision,
-                    rec.next_step,
+                    "ts",
+                    "run_id",
+                    "attempt_id",
+                    "claim_id",
+                    "hypothesis",
+                    "action",
+                    "budget_minutes",
+                    "input_sids",
+                    "output_sids",
+                    "audit_status",
+                    "decision",
+                    "next_step",
                 ]
             )
+            for rec in run.attempts:
+                writer.writerow(
+                    [
+                        f"{float(rec.created_at):.6f}",
+                        run.run_id,
+                        rec.attempt_id,
+                        rec.claim_id,
+                        rec.hypothesis,
+                        rec.action,
+                        f"{float(rec.budget_minutes):.2f}",
+                        ",".join(rec.input_sids),
+                        ",".join(rec.output_sids),
+                        rec.audit_status,
+                        rec.decision,
+                        rec.next_step,
+                    ]
+                )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def _persist_run(run: RunState) -> None:
-    try:
-        payload = {
-            "run_id": run.run_id,
-            "created_at": float(run.created_at),
-            "deliverable_sid": run.deliverable_sid,
-            "next_span_idx": int(run.next_span_idx),
-            "next_attempt_idx": int(run.next_attempt_idx),
-            "span_order": list(run.span_order),
-            "spans": {
-                sid: {
-                    "sid": rec.sid,
-                    "text": rec.text,
-                    "source": rec.source,
-                    "created_at": float(rec.created_at),
-                    "meta": dict(rec.meta or {}),
-                }
-                for sid, rec in run.spans.items()
-            },
-            "attempts": [
-                {
-                    "attempt_id": rec.attempt_id,
-                    "created_at": float(rec.created_at),
-                    "claim_id": rec.claim_id,
-                    "hypothesis": rec.hypothesis,
-                    "action": rec.action,
-                    "budget_minutes": float(rec.budget_minutes),
-                    "input_sids": list(rec.input_sids),
-                    "output_sids": list(rec.output_sids),
-                    "audit_status": rec.audit_status,
-                    "decision": rec.decision,
-                    "next_step": rec.next_step,
-                }
-                for rec in run.attempts
-            ],
-        }
-        _run_json_path(run.run_id).write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-        )
-        _write_evidence_tsv(run)
-        _write_attempts_tsv(run)
-    except Exception:
-        pass
+    _ledger_persist_run(run)
 
 
 def _load_persisted_run(run_id: str) -> RunState:
-    p = _run_json_path(run_id)
-    raw = json.loads(p.read_text(encoding="utf-8"))
-    rid = str(raw.get("run_id") or run_id).strip()
-    if not rid:
-        raise EnforcementError("Invalid persisted run: missing run_id")
-
-    run = RunState(run_id=rid, created_at=float(raw.get("created_at") or time.time()))
-    run.deliverable_sid = raw.get("deliverable_sid")
-    run.next_span_idx = int(raw.get("next_span_idx") or 0)
-    run.next_attempt_idx = int(raw.get("next_attempt_idx") or 0)
-
-    spans_raw = raw.get("spans") or {}
-    if isinstance(spans_raw, dict):
-        for sid, rec in spans_raw.items():
-            if not isinstance(rec, dict):
-                continue
-            s = SpanRecord(
-                sid=str(rec.get("sid") or sid),
-                text=str(rec.get("text") or ""),
-                source=str(rec.get("source") or "manual"),
-                created_at=float(rec.get("created_at") or time.time()),
-                meta=dict(rec.get("meta") or {}),
-            )
-            if s.text.strip():
-                run.spans[s.sid] = s
-
-    order = raw.get("span_order")
-    if isinstance(order, list):
-        run.span_order = [str(x) for x in order if str(x) in run.spans]
-    else:
-        # fallback: stable order by sid
-        run.span_order = sorted(run.spans.keys())
-
-    # Ensure next_span_idx is at least one more than the largest S#
-    try:
-        max_idx = -1
-        for sid in run.spans.keys():
-            if sid.startswith("S") and sid[1:].isdigit():
-                max_idx = max(max_idx, int(sid[1:]))
-        run.next_span_idx = max(run.next_span_idx, max_idx + 1)
-    except Exception:
-        pass
-
-    attempts_raw = raw.get("attempts") or []
-    if isinstance(attempts_raw, list):
-        for rec in attempts_raw:
-            if not isinstance(rec, dict):
-                continue
-            run.attempts.append(
-                AttemptRecord(
-                    attempt_id=str(rec.get("attempt_id") or f"A{len(run.attempts)}"),
-                    created_at=float(rec.get("created_at") or time.time()),
-                    claim_id=str(rec.get("claim_id") or ""),
-                    hypothesis=str(rec.get("hypothesis") or ""),
-                    action=str(rec.get("action") or ""),
-                    budget_minutes=float(rec.get("budget_minutes") or 0.0),
-                    input_sids=[
-                        str(v).strip() for v in (rec.get("input_sids") or []) if str(v).strip()
-                    ],
-                    output_sids=[
-                        str(v).strip() for v in (rec.get("output_sids") or []) if str(v).strip()
-                    ],
-                    audit_status=str(rec.get("audit_status") or ""),
-                    decision=str(rec.get("decision") or ""),
-                    next_step=str(rec.get("next_step") or ""),
-                )
-            )
-
-    return run
+    return _ledger_load_persisted_run(run_id)
 
 
 def _tokenize(q: str) -> List[str]:
@@ -332,19 +423,30 @@ def create_server(
         with _redirect_stdout_to_stderr():
             try:
                 run = store.start_run(run_id=run_id)
+                run.baseline_kind, run.baseline_ref = _capture_git_baseline(resolved_project_root)
 
-                # Anchor spans (not evidence, but captures intent).
+                # Anchor spans are immutable requirements/background, not verifier evidence.
                 ps = store.add_span(
                     run=run,
                     text=str(problem_statement or "").strip(),
                     source="anchor",
-                    meta={"kind": "problem"},
+                    source_type="user",
+                    kind="anchor",
+                    trust="manual",
+                    sensitivity="unknown",
+                    tags=["problem"],
+                    meta={"kind": "problem", "citable": False},
                 )
                 dv = store.add_span(
                     run=run,
                     text=str(deliverable or "").strip(),
                     source="anchor",
-                    meta={"kind": "deliverable", "immutable": True},
+                    source_type="user",
+                    kind="anchor",
+                    trust="manual",
+                    sensitivity="unknown",
+                    tags=["deliverable"],
+                    meta={"kind": "deliverable", "immutable": True, "citable": False},
                 )
                 run.deliverable_sid = dv.sid
 
@@ -354,8 +456,12 @@ def create_server(
                 return {
                     "run_id": run.run_id,
                     "run_dir": str(_run_dir(run.run_id)),
+                    "ledger_path": str(_run_sqlite_path(run.run_id)),
                     "problem_sid": ps.sid,
                     "deliverable_sid": dv.sid,
+                    "schema_version": 3,
+                    "baseline_kind": run.baseline_kind,
+                    "baseline_ref": run.baseline_ref,
                 }
             except EnforcementError as exc:
                 raise RuntimeError(str(exc))
@@ -374,6 +480,7 @@ def create_server(
                     return {
                         "run_id": run.run_id,
                         "run_dir": str(_run_dir(run.run_id)),
+                        "ledger_path": str(_run_sqlite_path(run.run_id)),
                         "status": "active",
                     }
                 except Exception:
@@ -386,6 +493,7 @@ def create_server(
                 return {
                     "run_id": run.run_id,
                     "run_dir": str(_run_dir(run.run_id)),
+                    "ledger_path": str(_run_sqlite_path(run.run_id)),
                     "status": "loaded",
                 }
             except FileNotFoundError:
@@ -419,15 +527,40 @@ def create_server(
         source: str = "manual",
         run_id: Optional[str] = None,
         meta: Optional[Dict[str, Any]] = None,
+        kind: str = "evidence",
+        source_type: Optional[str] = None,
+        trust: str = "primary",
+        sensitivity: str = "unknown",
+        tags: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
-        """Add evidence from text."""
+        """Add immutable text evidence to the server-owned run ledger."""
         with _redirect_stdout_to_stderr():
-            run = store.get_run(run_id)
-            rec = store.add_span(
-                run=run, text=str(text or ""), source=str(source or "manual"), meta=meta
-            )
-            _persist_run(run)
-            return {"run_id": run.run_id, "sid": rec.sid, "chars": len(rec.text)}
+            try:
+                run = store.get_run(run_id)
+                rec = store.add_span(
+                    run=run,
+                    text=str(text or ""),
+                    source=str(source or "manual"),
+                    source_type=str(source_type or source or "manual"),
+                    kind=str(kind or "evidence"),
+                    trust=str(trust or "primary"),
+                    sensitivity=str(sensitivity or "unknown"),
+                    tags=list(tags or []),
+                    meta=meta,
+                )
+                _persist_run(run)
+                return {
+                    "run_id": run.run_id,
+                    "sid": rec.sid,
+                    "eid": rec.eid,
+                    "kind": rec.kind,
+                    "trust": rec.trust,
+                    "sensitivity": rec.sensitivity,
+                    "chars": len(rec.text),
+                    "text_sha256": rec.text_sha256,
+                }
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
 
     @mcp.tool()
     def add_file_span(
@@ -437,44 +570,163 @@ def create_server(
         source: str = "file",
         run_id: Optional[str] = None,
         meta: Optional[Dict[str, Any]] = None,
+        read_mode: str = "baseline",
+        kind: str = "evidence",
+        trust: str = "primary",
+        sensitivity: str = "unknown",
+        tags: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
-        """Capture lines from a local file (path + line range) as evidence."""
+        """Capture a file line range as immutable evidence with file/git provenance."""
         with _redirect_stdout_to_stderr():
-            run = store.get_run(run_id)
-            p = resolve_user_path(Path(path), project_root=resolved_project_root)
-
-            decision = can_read_path(
-                p,
-                allowed_roots=getattr(cfg, "allowed_roots", []),
-                project_root=resolved_project_root,
-            )
-            if not decision.allowed:
-                raise RuntimeError(f"File read not allowed: {decision.reason}")
-
-            s = max(1, int(start_line))
-            e = max(s, int(end_line))
-            # cap to prevent huge spans
-            if (e - s) > 2000:
-                e = s + 2000
-
             try:
-                lines = p.read_text(encoding="utf-8").splitlines()
-            except UnicodeDecodeError:
-                lines = p.read_text(encoding="latin-1").splitlines()
+                run = store.get_run(run_id)
+                p = resolve_user_path(Path(path), project_root=resolved_project_root)
 
-            excerpt = "\n".join(lines[s - 1 : e])
-            m = dict(meta or {})
-            m.update({"path": str(p), "start_line": s, "end_line": e})
+                decision = can_read_path(
+                    p,
+                    allowed_roots=getattr(cfg, "allowed_roots", []),
+                    project_root=resolved_project_root,
+                )
+                if not decision.allowed:
+                    raise RuntimeError(f"File read not allowed: {decision.reason}")
 
-            rec = store.add_span(run=run, text=excerpt, source=str(source or "file"), meta=m)
-            _persist_run(run)
-            return {
-                "run_id": run.run_id,
-                "sid": rec.sid,
-                "path": str(p),
-                "start_line": s,
-                "end_line": e,
-            }
+                s_line = max(1, int(start_line))
+                e_line = max(s_line, int(end_line))
+                if (e_line - s_line) > 2000:
+                    e_line = s_line + 2000
+
+                rel = _rel_path(p, resolved_project_root)
+                requested_mode = str(read_mode or "baseline").strip().lower()
+                if requested_mode not in {"baseline", "worktree"}:
+                    raise RuntimeError("read_mode must be either 'baseline' or 'worktree'")
+                snapshot: Dict[str, Any] = {
+                    "requested_read_mode": requested_mode,
+                    "baseline_kind": run.baseline_kind,
+                    "baseline_ref": run.baseline_ref,
+                }
+
+                raw: bytes
+                actual_read_mode = "worktree"
+                if requested_mode == "baseline" and run.baseline_kind == "git" and run.baseline_ref:
+                    # Read exact object bytes from the immutable baseline commit.  This is
+                    # the safest evidence mode for source files because it prevents the
+                    # agent from citing code it just wrote as proof that it already existed.
+                    base_raw = _git_bytes(
+                        resolved_project_root, ["show", f"{run.baseline_ref}:{rel}"]
+                    )
+                    if base_raw is not None:
+                        raw = base_raw
+                        actual_read_mode = "baseline"
+                        snapshot["git_object"] = f"{run.baseline_ref}:{rel}"
+                    else:
+                        raw = p.read_bytes()
+                        snapshot["read_mode_fallback"] = "worktree_git_show_failed"
+                else:
+                    raw = p.read_bytes()
+                    if requested_mode == "baseline":
+                        snapshot["read_mode_fallback"] = "worktree_no_git_baseline"
+
+                snapshot["actual_read_mode"] = actual_read_mode
+                # Back-compat alias for older consumers that looked for read_mode.
+                snapshot["read_mode"] = actual_read_mode
+
+                text, encoding = _decode_bytes(raw)
+                lines = text.splitlines()
+                if s_line > len(lines):
+                    raise RuntimeError(
+                        f"start_line {s_line} is past end of file ({len(lines)} lines)"
+                    )
+                e_line = min(e_line, len(lines))
+                excerpt = "\n".join(lines[s_line - 1 : e_line]).strip("\n")
+                if not excerpt.strip():
+                    raise RuntimeError("Selected file span is empty")
+
+                offsets = _line_byte_offsets(raw)
+                start_byte = offsets[min(s_line - 1, len(offsets) - 1)]
+                end_byte = offsets[min(e_line, len(offsets) - 1)]
+
+                file_hash = hashlib.sha256(raw).hexdigest()
+                worktree_file_hash = _file_sha256(p) if p.exists() else ""
+                git_commit = _git_output(resolved_project_root, ["rev-parse", "--verify", "HEAD"])
+                git_status = _git_output(
+                    resolved_project_root, ["status", "--porcelain", "--", rel]
+                )
+                snapshot.update(
+                    {
+                        "file_sha256": file_hash,
+                        "worktree_file_sha256": worktree_file_hash,
+                        "git_commit": git_commit,
+                        "git_status": git_status,
+                        "line_count": len(lines),
+                    }
+                )
+                locator = {
+                    "path": str(p),
+                    "rel_path": rel,
+                    "start_line": s_line,
+                    "end_line": e_line,
+                    "start_byte": start_byte,
+                    "end_byte": end_byte,
+                    "encoding": encoding,
+                }
+                m = dict(meta or {})
+                m.update(locator)
+                m.update(
+                    {
+                        "file_sha256": file_hash,
+                        "worktree_file_sha256": worktree_file_hash,
+                        "git_commit": git_commit,
+                    }
+                )
+
+                effective_trust = str(trust or "primary")
+                if actual_read_mode != "baseline" and effective_trust == "primary":
+                    effective_trust = "worktree"
+                if git_status and actual_read_mode != "baseline":
+                    effective_trust = "worktree"
+                if (
+                    actual_read_mode == "baseline"
+                    and worktree_file_hash
+                    and worktree_file_hash != file_hash
+                ):
+                    snapshot["worktree_drift_from_baseline"] = True
+
+                rec = store.add_span(
+                    run=run,
+                    text=excerpt,
+                    source=str(source or "file"),
+                    source_type="file",
+                    kind=str(kind or "evidence"),
+                    media_type="text/plain",
+                    locator=locator,
+                    snapshot=snapshot,
+                    trust=effective_trust,
+                    sensitivity=str(sensitivity or "unknown"),
+                    tags=list(tags or []) + ["file"],
+                    meta=m,
+                )
+                _persist_run(run)
+                return {
+                    "run_id": run.run_id,
+                    "sid": rec.sid,
+                    "eid": rec.eid,
+                    "path": str(p),
+                    "rel_path": rel,
+                    "start_line": s_line,
+                    "end_line": e_line,
+                    "start_byte": start_byte,
+                    "end_byte": end_byte,
+                    "encoding": encoding,
+                    "file_sha256": file_hash,
+                    "worktree_file_sha256": worktree_file_hash,
+                    "git_commit": git_commit,
+                    "git_status": git_status,
+                    "trust": rec.trust,
+                    "sensitivity": rec.sensitivity,
+                }
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
+
 
     @mcp.tool()
     def record_attempt(
@@ -525,60 +777,315 @@ def create_server(
                 "attempts": store.list_attempts(run=run, limit=int(limit or 200)),
             }
 
+    # -----------------------------
+    # Claim / evidence graph
+    # -----------------------------
+
     @mcp.tool()
-    def list_spans(run_id: Optional[str] = None, limit: int = 200) -> Dict[str, Any]:
-        """List all spans (metadata only)."""
+    def create_claim(
+        text: str,
+        run_id: Optional[str] = None,
+        kind: str = "fact",
+        target: float = 0.95,
+        status: str = "open",
+        source: str = "manual",
+        tags: Optional[List[str]] = None,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Create a structured claim node that can be linked to evidence and audited."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                claim = store.create_claim(
+                    run=run,
+                    text=text,
+                    kind=kind,
+                    target=float(target or 0.95),
+                    status=status,
+                    source=source,
+                    tags=list(tags or []),
+                    meta=dict(meta or {}),
+                )
+                _persist_run(run)
+                return {"run_id": run.run_id, "claim": claim.to_public_dict()}
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
+
+    @mcp.tool()
+    def link_claim_evidence(
+        cid: str,
+        sid: str,
+        run_id: Optional[str] = None,
+        relation: str = "supports",
+        note: str = "",
+        audit_id: str = "",
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Add a typed edge between a claim and a run-owned evidence span."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                link = store.link_claim_evidence(
+                    run=run,
+                    cid=cid,
+                    sid=sid,
+                    relation=relation,
+                    created_by="manual",
+                    audit_id=audit_id,
+                    note=note,
+                    meta=dict(meta or {}),
+                )
+                _persist_run(run)
+                return {"run_id": run.run_id, "link": link.to_public_dict()}
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
+
+    @mcp.tool()
+    def list_claims(
+        run_id: Optional[str] = None,
+        limit: int = 200,
+        status: Optional[List[str]] = None,
+        kinds: Optional[List[str]] = None,
+        include_evidence: bool = True,
+    ) -> Dict[str, Any]:
+        """List structured claims and, optionally, their evidence edges."""
         with _redirect_stdout_to_stderr():
             run = store.get_run(run_id)
             return {
                 "run_id": run.run_id,
-                "spans": store.list_spans(run=run, limit=int(limit or 200)),
+                "claims": store.list_claims(
+                    run=run,
+                    limit=int(limit or 200),
+                    status=status,
+                    kinds=kinds,
+                    include_evidence=bool(include_evidence),
+                ),
             }
 
     @mcp.tool()
-    def get_span(sid: str, run_id: Optional[str] = None) -> Dict[str, Any]:
-        """Fetch full span text."""
+    def get_claim(
+        cid: str,
+        run_id: Optional[str] = None,
+        include_evidence: bool = True,
+        include_audits: bool = True,
+    ) -> Dict[str, Any]:
+        """Fetch a claim node with evidence and audit history."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                claim = store.get_claim(run=run, cid=cid)
+                data = claim.to_public_dict()
+                if include_evidence:
+                    data["evidence"] = store.list_claim_evidence(run=run, cid=claim.cid)
+                if include_audits:
+                    data["audits"] = store.list_audits(run=run, claim_id=claim.cid)
+                return {"run_id": run.run_id, "claim": data}
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
+
+    @mcp.tool()
+    def mark_claim(
+        cid: str,
+        run_id: Optional[str] = None,
+        status: Optional[str] = None,
+        kind: Optional[str] = None,
+        target: Optional[float] = None,
+        latest_audit_id: Optional[str] = None,
+        tags_add: Optional[List[str]] = None,
+        tags_remove: Optional[List[str]] = None,
+        meta_update: Optional[Dict[str, Any]] = None,
+        reason: str = "",
+    ) -> Dict[str, Any]:
+        """Update mutable claim annotations without changing immutable claim text."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                meta = dict(meta_update or {})
+                if reason:
+                    meta["last_mark_reason"] = str(reason)
+                claim = store.update_claim(
+                    run=run,
+                    cid=cid,
+                    status=status,
+                    kind=kind,
+                    target=target,
+                    latest_audit_id=latest_audit_id,
+                    tags_add=list(tags_add or []),
+                    tags_remove=list(tags_remove or []),
+                    meta_update=meta,
+                )
+                _persist_run(run)
+                return {"run_id": run.run_id, "claim": claim.to_public_dict()}
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
+
+    @mcp.tool()
+    def list_claim_evidence(
+        run_id: Optional[str] = None,
+        cid: Optional[str] = None,
+        sid: Optional[str] = None,
+        relation: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """List typed claim/evidence edges with optional claim/span/relation filters."""
         with _redirect_stdout_to_stderr():
             run = store.get_run(run_id)
-            k = str(sid or "").strip()
-            if k not in run.spans:
-                raise RuntimeError(f"Unknown span sid: {k}")
-            rec = run.spans[k]
             return {
                 "run_id": run.run_id,
-                "sid": rec.sid,
-                "text": rec.text,
-                "source": rec.source,
-                "created_at": rec.created_at,
-                "meta": rec.meta,
+                "links": store.list_claim_evidence(run=run, cid=cid, sid=sid, relation=relation),
             }
+
+    @mcp.tool()
+    def list_audits(
+        run_id: Optional[str] = None,
+        claim_id: Optional[str] = None,
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        """List verifier audit records from the claim/evidence graph."""
+        with _redirect_stdout_to_stderr():
+            run = store.get_run(run_id)
+            return {
+                "run_id": run.run_id,
+                "audits": store.list_audits(run=run, claim_id=claim_id, limit=int(limit or 100)),
+            }
+
+    @mcp.tool()
+    def list_spans(
+        run_id: Optional[str] = None,
+        limit: int = 200,
+        kinds: Optional[List[str]] = None,
+        source_types: Optional[List[str]] = None,
+        trust: Optional[List[str]] = None,
+        status: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """List span metadata with v2 provenance, lifecycle, and sensitivity fields."""
+        with _redirect_stdout_to_stderr():
+            run = store.get_run(run_id)
+            return {
+                "run_id": run.run_id,
+                "schema_version": 3,
+                "spans": store.list_spans(
+                    run=run,
+                    limit=int(limit or 200),
+                    kinds=kinds,
+                    source_types=source_types,
+                    trust=trust,
+                    status=status,
+                ),
+            }
+
+    @mcp.tool()
+    def get_span(
+        sid: str,
+        run_id: Optional[str] = None,
+        include_sensitive_text: bool = False,
+    ) -> Dict[str, Any]:
+        """Fetch a span. Sensitive text is redacted unless explicitly requested."""
+        with _redirect_stdout_to_stderr():
+            run = store.get_run(run_id)
+            try:
+                rec = store.get_span(run=run, sid=sid)
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
+            data = rec.to_public_dict(
+                include_text=True,
+                preview_chars=240,
+                redact_sensitive=not bool(include_sensitive_text),
+            )
+            data["run_id"] = run.run_id
+            return data
+
+    @mcp.tool()
+    def mark_span(
+        sid: str,
+        run_id: Optional[str] = None,
+        status: Optional[str] = None,
+        sensitivity: Optional[str] = None,
+        tags_add: Optional[List[str]] = None,
+        tags_remove: Optional[List[str]] = None,
+        trust: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update mutable span annotations without mutating immutable evidence text."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                rec = store.mark_span(
+                    run=run,
+                    sid=sid,
+                    status=status,
+                    sensitivity=sensitivity,
+                    tags_add=tags_add,
+                    tags_remove=tags_remove,
+                    trust=trust,
+                )
+                _persist_run(run)
+                return {"run_id": run.run_id, "span": rec.to_public_dict(include_text=False)}
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
 
     @mcp.tool()
     def search_spans(query: str, run_id: Optional[str] = None, limit: int = 10) -> Dict[str, Any]:
-        """Search over span texts (lightweight token match scoring)."""
+        """Backward-compatible lexical search over active non-derived spans."""
         with _redirect_stdout_to_stderr():
             run = store.get_run(run_id)
-            tokens = _tokenize(query)
-            scored: List[Tuple[float, SpanRecord]] = []
-            for sid in run.span_order:
-                rec = run.spans[sid]
-                s = _score_text(rec.text, tokens)
-                if s > 0:
-                    scored.append((s, rec))
-            scored.sort(key=lambda x: (-x[0], x[1].sid))
-            out = []
-            for score, rec in scored[: max(1, int(limit or 10))]:
-                preview = rec.text.strip().replace("\n", " ")[:200]
-                out.append(
-                    {
-                        "sid": rec.sid,
-                        "score": score,
-                        "preview": preview,
-                        "source": rec.source,
-                        "meta": rec.meta,
-                    }
+            results = store.query_evidence(run=run, query=query, limit=int(limit or 10))
+            return {"run_id": run.run_id, "query": query, "results": results}
+
+    @mcp.tool()
+    def query_evidence(
+        query: str,
+        run_id: Optional[str] = None,
+        limit: int = 10,
+        kinds: Optional[List[str]] = None,
+        source_types: Optional[List[str]] = None,
+        trust: Optional[List[str]] = None,
+        status: Optional[List[str]] = None,
+        include_derived: bool = False,
+        include_stale: bool = False,
+    ) -> Dict[str, Any]:
+        """Search the evidence ledger with kind/source/trust/status filters."""
+        with _redirect_stdout_to_stderr():
+            run = store.get_run(run_id)
+            results = store.query_evidence(
+                run=run,
+                query=query,
+                limit=int(limit or 10),
+                kinds=kinds,
+                source_types=source_types,
+                trust=trust,
+                status=status,
+                include_derived=bool(include_derived),
+                include_stale=bool(include_stale),
+            )
+            return {"run_id": run.run_id, "query": query, "results": results}
+
+    @mcp.tool()
+    def extract_span(
+        parent_sid: str,
+        selector: Dict[str, Any],
+        run_id: Optional[str] = None,
+        reason: str = "",
+        source: str = "extract",
+        max_lines: int = 200,
+        tags: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Create an offset-preserving derived span from a regex or line-range selector."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                res = store.extract_span(
+                    run=run,
+                    parent_sid=str(parent_sid or ""),
+                    selector=dict(selector or {}),
+                    reason=str(reason or ""),
+                    source=str(source or "extract"),
+                    max_lines=int(max_lines or 200),
+                    tags=list(tags or []),
                 )
-            return {"run_id": run.run_id, "query": query, "results": out}
+                if res.get("matched"):
+                    _persist_run(run)
+                return {"run_id": run.run_id, **res}
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
 
     @mcp.tool()
     def distill_span(
@@ -589,47 +1096,46 @@ def create_server(
         flags: str = "i",
         max_lines: int = 200,
     ) -> Dict[str, Any]:
-        """Extract key lines from a large span (regex-based), creating a new span."""
+        """Compatibility wrapper for regex extraction. No-match creates no evidence span."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                res = store.extract_span(
+                    run=run,
+                    parent_sid=str(parent_sid or ""),
+                    selector={"type": "regex", "pattern": str(pattern or ""), "flags": flags},
+                    reason="distill_span compatibility extraction",
+                    source=str(source or "distill"),
+                    max_lines=int(max_lines or 200),
+                    tags=["distilled"],
+                )
+                if res.get("matched"):
+                    _persist_run(run)
+                return {"run_id": run.run_id, "lines": len(res.get("matches") or []), **res}
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
+
+    @mcp.tool()
+    def get_evidence_pack(
+        sids: List[str],
+        run_id: Optional[str] = None,
+        max_chars: int = 12000,
+        allow_sensitive: bool = False,
+        include_stale: bool = False,
+        allow_untrusted: bool = False,
+    ) -> Dict[str, Any]:
+        """Resolve run-owned SIDs into the exact verifier-safe evidence pack."""
         with _redirect_stdout_to_stderr():
             run = store.get_run(run_id)
-            psid = str(parent_sid or "").strip()
-            if psid not in run.spans:
-                raise RuntimeError(f"Unknown parent span sid: {psid}")
-
-            fl = 0
-            if "i" in (flags or ""):
-                fl |= re.IGNORECASE
-            if "m" in (flags or ""):
-                fl |= re.MULTILINE
-
-            try:
-                rx = re.compile(str(pattern or ""), fl)
-            except Exception as exc:
-                raise RuntimeError(f"Invalid regex pattern: {exc}")
-
-            parent = run.spans[psid]
-            matched: List[str] = []
-            for line in parent.text.splitlines():
-                if rx.search(line):
-                    matched.append(line)
-                    if len(matched) >= max(1, int(max_lines or 200)):
-                        break
-
-            distilled = "\n".join(matched).strip()
-            if not distilled:
-                distilled = "[no lines matched]"
-
-            meta = {
-                "parent_sid": psid,
-                "pattern": pattern,
-                "flags": flags,
-                "max_lines": int(max_lines or 200),
-            }
-            rec = store.add_span(
-                run=run, text=distilled, source=str(source or "distill"), meta=meta
+            pack = store.resolve_evidence_pack(
+                run=run,
+                sids=list(sids or []),
+                max_chars=int(max_chars or 12000),
+                allow_sensitive=bool(allow_sensitive),
+                include_stale=bool(include_stale),
+                allow_untrusted=bool(allow_untrusted),
             )
-            _persist_run(run)
-            return {"run_id": run.run_id, "sid": rec.sid, "parent_sid": psid, "lines": len(matched)}
+            return pack
 
     # -----------------------------
     # Verification tools (local core implementation)
@@ -642,6 +1148,559 @@ def create_server(
             or (os.environ.get("BERRY_MODEL") or "").strip()
             or "gpt-4o-mini"
         )
+
+    def _pack_summary(pack: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "pack_id": pack.get("pack_id"),
+            "text_sha256": pack.get("text_sha256"),
+            "input_sids": list(pack.get("input_sids") or []),
+            "materialized_sids": list(pack.get("materialized_sids") or []),
+            "excluded": list(pack.get("excluded") or []),
+            "chars": int(pack.get("chars") or 0),
+            "truncated": bool(pack.get("truncated")),
+            "policy": dict(pack.get("policy") or {}),
+        }
+
+    def _detail_by_idx(report: Dict[str, Any]) -> Dict[int, Dict[str, Any]]:
+        out: Dict[int, Dict[str, Any]] = {}
+        for detail in report.get("details") or []:
+            if not isinstance(detail, dict):
+                continue
+            try:
+                idx = int(detail.get("idx"))
+            except Exception:
+                continue
+            out[idx] = detail
+        return out
+
+    def _claim_status_from_detail(detail: Dict[str, Any]) -> str:
+        status = str(detail.get("status") or "").strip().lower()
+        if status == "passed":
+            return "supported"
+        if status == "contradicted":
+            return "contradicted"
+        if status in {"missing_citations", "unknown_citations", "empty_context", "no_spans"}:
+            return "open"
+        return "insufficient"
+
+    def _claim_relation_from_detail(detail: Dict[str, Any]) -> str:
+        status = str(detail.get("status") or "").strip().lower()
+        if status == "contradicted":
+            return "contradicts"
+        if status == "passed":
+            return "supports"
+        return "insufficient"
+
+    def _claim_id_for_step(
+        *, run: RunState, step: Dict[str, Any], kind: str, auto_create_claims: bool
+    ) -> str:
+        raw = step.get("claim_id", step.get("cid", ""))
+        cid = str(raw or "").strip()
+        if cid:
+            store.get_claim(run=run, cid=cid)
+            return cid
+        if not auto_create_claims:
+            return ""
+        claim = store.create_claim(
+            run=run,
+            text=str(step.get("claim") or ""),
+            kind="fact",
+            target=float(step.get("confidence") or 0.95),
+            status="open",
+            source=kind,
+            tags=["auto-created"],
+            meta={"created_from_step_idx": step.get("idx")},
+        )
+        step["claim_id"] = claim.cid
+        return claim.cid
+
+    def _record_audit_graph(
+        *,
+        run: RunState,
+        kind: str,
+        steps: List[Dict[str, Any]],
+        pack: Dict[str, Any],
+        report: Dict[str, Any],
+        verifier_model: str,
+        audit_sid: str,
+        auto_create_claims: bool = False,
+    ) -> str:
+        details = _detail_by_idx(report)
+        claim_ids: List[str] = []
+        for step in steps or []:
+            if not isinstance(step, dict):
+                continue
+            cid = _claim_id_for_step(
+                run=run,
+                step=step,
+                kind=kind,
+                auto_create_claims=auto_create_claims,
+            )
+            if cid and cid not in claim_ids:
+                claim_ids.append(cid)
+        audit = store.record_audit(
+            run=run,
+            kind=kind,
+            claim_ids=claim_ids,
+            input_sids=list(pack.get("input_sids") or []),
+            materialized_sids=list(pack.get("materialized_sids") or []),
+            evidence_pack_id=str(pack.get("pack_id") or ""),
+            evidence_pack_hash=str(pack.get("text_sha256") or ""),
+            verifier_model=verifier_model,
+            policy=dict(pack.get("policy") or {}),
+            result={
+                "flagged": bool(report.get("flagged", True)),
+                "summary": dict(report.get("summary") or {}),
+                "details_sha256": hashlib.sha256(
+                    json.dumps(
+                        report.get("details") or [], sort_keys=True, default=str
+                    ).encode("utf-8")
+                ).hexdigest(),
+            },
+            audit_sid=audit_sid,
+        )
+        materialized = {str(s) for s in (pack.get("materialized_sids") or [])}
+        for i, step in enumerate(steps or []):
+            if not isinstance(step, dict):
+                continue
+            cid = str(step.get("claim_id") or step.get("cid") or "").strip()
+            if not cid:
+                continue
+            try:
+                idx = int(step.get("idx", i))
+            except Exception:
+                idx = i
+            detail = details.get(idx, {})
+            store.update_claim(
+                run=run,
+                cid=cid,
+                status=_claim_status_from_detail(detail),
+                latest_audit_id=audit.audit_id,
+                meta_update={"latest_detail_status": detail.get("status", "")},
+            )
+            relation = _claim_relation_from_detail(detail)
+            for raw_sid in step.get("cites") or []:
+                sid = str(raw_sid or "").strip()
+                if not sid or sid not in materialized:
+                    continue
+                try:
+                    store.link_claim_evidence(
+                        run=run,
+                        cid=cid,
+                        sid=sid,
+                        relation=relation,
+                        created_by="audit",
+                        audit_id=audit.audit_id,
+                        note=str(detail.get("status") or ""),
+                        meta={"detail_idx": idx},
+                    )
+                except EnforcementError:
+                    # The pack resolver already checked materialized spans. Keep the
+                    # audit record even if a concurrent annotation made one edge invalid.
+                    continue
+        return audit.audit_id
+
+    def _record_audit_span(
+        *,
+        run: RunState,
+        kind: str,
+        pack: Dict[str, Any],
+        report: Dict[str, Any],
+        verifier_model: str,
+    ) -> str:
+        payload = {
+            "type": kind,
+            "evidence_pack": _pack_summary(pack),
+            "flagged": bool(report.get("flagged", True)),
+            "summary": dict(report.get("summary") or {}),
+            "verifier_model": verifier_model,
+            "created_at": time.time(),
+        }
+        # Prompts/details can be large or sensitive.  The audit span stores the
+        # pack hash and summary by default, not full verifier context.
+        rec = store.add_span(
+            run=run,
+            text=json.dumps(payload, indent=2, sort_keys=True),
+            source="verifier",
+            source_type="verifier",
+            kind="audit",
+            media_type="application/json",
+            parents=list(pack.get("materialized_sids") or []),
+            trust="derived",
+            sensitivity="unknown",
+            tags=["audit", kind],
+            meta={"pack_id": pack.get("pack_id"), "verifier_model": verifier_model},
+        )
+        return rec.sid
+
+    def _resolve_pack_or_error(
+        *,
+        run: RunState,
+        sids: List[str],
+        max_chars: int,
+        allow_sensitive: bool,
+        include_stale: bool,
+        allow_untrusted: bool,
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+        if not sids:
+            pack = store.resolve_evidence_pack(run=run, sids=[], max_chars=max_chars)
+            return None, _fail_closed_report(
+                error=(
+                    "No cited SIDs were provided; server-resolved verification requires "
+                    "explicit run-owned citations."
+                ),
+                pack=_pack_summary(pack),
+            )
+        pack = store.resolve_evidence_pack(
+            run=run,
+            sids=sids,
+            max_chars=max_chars,
+            allow_sensitive=allow_sensitive,
+            include_stale=include_stale,
+            allow_untrusted=allow_untrusted,
+        )
+        if pack.get("excluded"):
+            return None, _fail_closed_report(
+                error=(
+                    "Evidence pack contains unknown, unsafe, stale, non-citable, "
+                    "or over-budget spans."
+                ),
+                pack=_pack_summary(pack),
+            )
+        if not pack.get("spans"):
+            return None, _fail_closed_report(
+                error="Evidence pack is empty after policy filtering.", pack=_pack_summary(pack)
+            )
+        return pack, None
+
+    @mcp.tool()
+    def audit_trace_budget_run(
+        steps: List[Dict[str, Any]],
+        run_id: Optional[str] = None,
+        sid_whitelist: Optional[List[str]] = None,
+        verifier_model: Optional[str] = None,
+        default_target: float = 0.95,
+        require_citations: bool = True,
+        context_mode: str = "cited",
+        include_prompts: bool = False,
+        max_prompt_chars: int = 3000,
+        top_logprobs: int = 5,
+        min_log_odds_gain: float = 0.0,
+        use_cache: bool = True,
+        group_claims: bool = True,
+        max_group_size: int = 8,
+        max_group_prompt_chars: int = 24000,
+        timeout_s: float = 60.0,
+        max_evidence_chars: int = 12000,
+        allow_sensitive: bool = False,
+        include_stale: bool = False,
+        allow_untrusted: bool = False,
+        record_audit: bool = True,
+        record_claim_graph: bool = True,
+        auto_create_claims: bool = False,
+    ) -> Dict[str, Any]:
+        """Audit explicit claims using server-resolved run spans, not caller-supplied text."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                step_list = list(steps or [])
+                cited = _collect_step_cites(step_list)
+                if bool(require_citations):
+                    missing = [
+                        int(st.get("idx", i))
+                        for i, st in enumerate(step_list)
+                        if not (st.get("cites") or [])
+                    ]
+                    if missing:
+                        return _fail_closed_report(
+                            error=f"Steps missing citations: {missing}",
+                            pack={"input_sids": cited, "materialized_sids": []},
+                        )
+                if sid_whitelist:
+                    allowed = {str(s).strip() for s in sid_whitelist if str(s).strip()}
+                    outside = [sid for sid in cited if sid not in allowed]
+                    if outside:
+                        return _fail_closed_report(
+                            error=f"Steps cite SIDs outside sid_whitelist: {outside}",
+                            pack={"input_sids": cited, "materialized_sids": []},
+                        )
+                    pack_sids = cited or list(allowed)
+                else:
+                    pack_sids = cited
+
+                pack, err = _resolve_pack_or_error(
+                    run=run,
+                    sids=pack_sids,
+                    max_chars=int(max_evidence_chars or 12000),
+                    allow_sensitive=bool(allow_sensitive),
+                    include_stale=bool(include_stale),
+                    allow_untrusted=bool(allow_untrusted),
+                )
+                if err:
+                    return err
+                assert pack is not None
+
+                model = str(verifier_model or _default_verifier_model())
+                try:
+                    report = run_audit_trace_budget(
+                        steps=step_list,
+                        spans=list(pack.get("spans") or []),
+                        verifier_model=model,
+                        default_target=float(default_target or 0.95),
+                        require_citations=bool(require_citations),
+                        context_mode=str(context_mode or "cited"),
+                        include_prompts=bool(include_prompts),
+                        max_prompt_chars=int(max_prompt_chars or 3000),
+                        top_logprobs=int(top_logprobs or 5),
+                        min_log_odds_gain=float(min_log_odds_gain),
+                        use_cache=bool(use_cache),
+                        group_claims=bool(group_claims),
+                        max_group_size=max_group_size,
+                        max_group_prompt_chars=max_group_prompt_chars,
+                        timeout_s=float(timeout_s or 60.0),
+                    )
+                    report.setdefault("summary", {})["evidence_pack"] = _pack_summary(pack)
+                except Exception as exc:
+                    report = _fail_closed_report(error=str(exc), pack=_pack_summary(pack))
+                if bool(record_audit):
+                    audit_sid = _record_audit_span(
+                        run=run,
+                        kind="audit_trace_budget_run",
+                        pack=pack,
+                        report=report,
+                        verifier_model=model,
+                    )
+                    report["summary"]["audit_sid"] = audit_sid
+                    if bool(record_claim_graph):
+                        report["summary"]["audit_id"] = _record_audit_graph(
+                            run=run,
+                            kind="audit_trace_budget_run",
+                            steps=step_list,
+                            pack=pack,
+                            report=report,
+                            verifier_model=model,
+                            audit_sid=audit_sid,
+                            auto_create_claims=bool(auto_create_claims),
+                        )
+                    _persist_run(run)
+                return report
+            except Exception as e:
+                return {"flagged": True, "under_budget": True, "error": str(e), "details": []}
+
+    @mcp.tool()
+    def audit_claims(
+        claim_ids: Optional[List[str]] = None,
+        run_id: Optional[str] = None,
+        evidence_relations: Optional[List[str]] = None,
+        verifier_model: Optional[str] = None,
+        context_mode: str = "cited",
+        include_prompts: bool = False,
+        max_prompt_chars: int = 3000,
+        top_logprobs: int = 5,
+        min_log_odds_gain: float = 0.0,
+        use_cache: bool = True,
+        group_claims: bool = True,
+        max_group_size: int = 8,
+        max_group_prompt_chars: int = 24000,
+        timeout_s: float = 60.0,
+        max_evidence_chars: int = 12000,
+        allow_sensitive: bool = False,
+        include_stale: bool = False,
+        allow_untrusted: bool = False,
+        max_claims: int = 25,
+        record_audit: bool = True,
+    ) -> Dict[str, Any]:
+        """Audit claims from the structured claim/evidence graph."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                step_list = store.claim_steps(
+                    run=run,
+                    claim_ids=list(claim_ids or []),
+                    max_claims=int(max_claims or 25),
+                    evidence_relations=list(evidence_relations or ["supports", "background"]),
+                )
+                if not step_list:
+                    return _fail_closed_report(
+                        error="No auditable claims found. Create claims and link evidence first.",
+                        pack={"input_sids": [], "materialized_sids": []},
+                    )
+                missing = [st["claim_id"] for st in step_list if not st.get("cites")]
+                if missing:
+                    return _fail_closed_report(
+                        error=f"Claims have no linked evidence: {missing}",
+                        pack={"input_sids": [], "materialized_sids": []},
+                    )
+                cited = _collect_step_cites(step_list)
+                pack, err = _resolve_pack_or_error(
+                    run=run,
+                    sids=cited,
+                    max_chars=int(max_evidence_chars or 12000),
+                    allow_sensitive=bool(allow_sensitive),
+                    include_stale=bool(include_stale),
+                    allow_untrusted=bool(allow_untrusted),
+                )
+                if err:
+                    return err
+                assert pack is not None
+
+                model = str(verifier_model or _default_verifier_model())
+                try:
+                    report = run_audit_trace_budget(
+                        steps=step_list,
+                        spans=list(pack.get("spans") or []),
+                        verifier_model=model,
+                        default_target=0.95,
+                        require_citations=True,
+                        context_mode=str(context_mode or "cited"),
+                        include_prompts=bool(include_prompts),
+                        max_prompt_chars=int(max_prompt_chars or 3000),
+                        top_logprobs=int(top_logprobs or 5),
+                        min_log_odds_gain=float(min_log_odds_gain),
+                        use_cache=bool(use_cache),
+                        group_claims=bool(group_claims),
+                        max_group_size=max_group_size,
+                        max_group_prompt_chars=max_group_prompt_chars,
+                        timeout_s=float(timeout_s or 60.0),
+                    )
+                    report.setdefault("summary", {})["evidence_pack"] = _pack_summary(pack)
+                    report["summary"]["claim_ids"] = [st["claim_id"] for st in step_list]
+                except Exception as exc:
+                    report = _fail_closed_report(error=str(exc), pack=_pack_summary(pack))
+                if bool(record_audit):
+                    audit_sid = _record_audit_span(
+                        run=run,
+                        kind="audit_claims",
+                        pack=pack,
+                        report=report,
+                        verifier_model=model,
+                    )
+                    report.setdefault("summary", {})["audit_sid"] = audit_sid
+                    report["summary"]["audit_id"] = _record_audit_graph(
+                        run=run,
+                        kind="audit_claims",
+                        steps=step_list,
+                        pack=pack,
+                        report=report,
+                        verifier_model=model,
+                        audit_sid=audit_sid,
+                    )
+                    _persist_run(run)
+                return report
+            except Exception as e:
+                return {"flagged": True, "under_budget": True, "error": str(e), "details": []}
+
+    @mcp.tool()
+    def detect_hallucination_run(
+        answer: str,
+        run_id: Optional[str] = None,
+        sid_whitelist: Optional[List[str]] = None,
+        verifier_model: Optional[str] = None,
+        default_target: float = 0.95,
+        max_claims: int = 25,
+        claim_split: str = "sentences",
+        require_citations: bool = True,
+        context_mode: str = "cited",
+        include_prompts: bool = False,
+        max_prompt_chars: int = 3000,
+        top_logprobs: int = 5,
+        min_log_odds_gain: float = 0.0,
+        use_cache: bool = True,
+        group_claims: bool = True,
+        max_group_size: int = 8,
+        max_group_prompt_chars: int = 24000,
+        timeout_s: float = 60.0,
+        max_evidence_chars: int = 12000,
+        allow_sensitive: bool = False,
+        include_stale: bool = False,
+        allow_untrusted: bool = False,
+        record_audit: bool = True,
+        record_claim_graph: bool = True,
+    ) -> Dict[str, Any]:
+        """Detect answer hallucinations using citations resolved from the server-owned run."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                cited = _extract_cited_sids(str(answer or ""))
+                if bool(require_citations) and not cited:
+                    return _fail_closed_report(
+                        error=(
+                            "No [S#] citations found in answer; server-resolved "
+                            "detection requires explicit citations."
+                        ),
+                        pack={"input_sids": [], "materialized_sids": []},
+                    )
+                if sid_whitelist:
+                    allowed = {str(s).strip() for s in sid_whitelist if str(s).strip()}
+                    outside = [sid for sid in cited if sid not in allowed]
+                    if outside:
+                        return _fail_closed_report(
+                            error=f"Answer cites SIDs outside sid_whitelist: {outside}",
+                            pack={"input_sids": cited, "materialized_sids": []},
+                        )
+                    pack_sids = cited or list(allowed)
+                else:
+                    pack_sids = cited
+
+                pack, err = _resolve_pack_or_error(
+                    run=run,
+                    sids=pack_sids,
+                    max_chars=int(max_evidence_chars or 12000),
+                    allow_sensitive=bool(allow_sensitive),
+                    include_stale=bool(include_stale),
+                    allow_untrusted=bool(allow_untrusted),
+                )
+                if err:
+                    return err
+                assert pack is not None
+
+                model = str(verifier_model or _default_verifier_model())
+                try:
+                    report = run_detect_hallucination(
+                        answer=str(answer or ""),
+                        spans=list(pack.get("spans") or []),
+                        verifier_model=model,
+                        default_target=float(default_target or 0.95),
+                        max_claims=int(max_claims or 25),
+                        claim_split=str(claim_split or "sentences"),
+                        require_citations=bool(require_citations),
+                        context_mode=str(context_mode or "cited"),
+                        include_prompts=bool(include_prompts),
+                        max_prompt_chars=int(max_prompt_chars or 3000),
+                        top_logprobs=int(top_logprobs or 5),
+                        min_log_odds_gain=float(min_log_odds_gain),
+                        use_cache=bool(use_cache),
+                        group_claims=bool(group_claims),
+                        max_group_size=max_group_size,
+                        max_group_prompt_chars=max_group_prompt_chars,
+                        timeout_s=float(timeout_s or 60.0),
+                    )
+                    report.setdefault("summary", {})["evidence_pack"] = _pack_summary(pack)
+                except Exception as exc:
+                    report = _fail_closed_report(error=str(exc), pack=_pack_summary(pack))
+                if bool(record_audit):
+                    audit_sid = _record_audit_span(
+                        run=run,
+                        kind="detect_hallucination_run",
+                        pack=pack,
+                        report=report,
+                        verifier_model=model,
+                    )
+                    report["summary"]["audit_sid"] = audit_sid
+                    if bool(record_claim_graph):
+                        report["summary"]["audit_id"] = _record_audit_graph(
+                            run=run,
+                            kind="detect_hallucination_run",
+                            steps=[],
+                            pack=pack,
+                            report=report,
+                            verifier_model=model,
+                            audit_sid=audit_sid,
+                        )
+                    _persist_run(run)
+                return report
+            except Exception as e:
+                return {"flagged": True, "under_budget": True, "error": str(e), "details": []}
 
     @mcp.tool()
     def detect_hallucination(

--- a/src/berry/mcp_server.py
+++ b/src/berry/mcp_server.py
@@ -62,13 +62,29 @@ from .permissions import can_read_path
 from .prompts import list_prompts
 from .run_ledger import (
     atomic_write_text as _ledger_atomic_write_text,
+)
+from .run_ledger import (
     attempts_tsv_path as _ledger_attempts_tsv_path,
+)
+from .run_ledger import (
     evidence_tsv_path as _ledger_evidence_tsv_path,
+)
+from .run_ledger import (
     load_persisted_run as _ledger_load_persisted_run,
+)
+from .run_ledger import (
     persist_run as _ledger_persist_run,
+)
+from .run_ledger import (
     run_dir as _ledger_run_dir,
+)
+from .run_ledger import (
     run_json_path as _ledger_run_json_path,
+)
+from .run_ledger import (
     run_sqlite_path as _ledger_run_sqlite_path,
+)
+from .run_ledger import (
     span_to_payload as _ledger_span_to_payload,
 )
 
@@ -212,7 +228,7 @@ def _extract_cited_sids(text: str) -> List[str]:
     return out
 
 
-def _collect_step_cites(steps: List[Dict[str, Any]]) -> List[str]:
+def _collect_step_cites(steps: List[Any]) -> List[str]:
     seen = set()
     out: List[str] = []
     for st in steps or []:
@@ -727,7 +743,6 @@ def create_server(
             except EnforcementError as exc:
                 raise RuntimeError(str(exc))
 
-
     @mcp.tool()
     def record_attempt(
         claim_id: str,
@@ -1167,7 +1182,7 @@ def create_server(
             if not isinstance(detail, dict):
                 continue
             try:
-                idx = int(detail.get("idx"))
+                idx = int(detail["idx"])
             except Exception:
                 continue
             out[idx] = detail
@@ -1218,7 +1233,7 @@ def create_server(
         *,
         run: RunState,
         kind: str,
-        steps: List[Dict[str, Any]],
+        steps: List[Any],
         pack: Dict[str, Any],
         report: Dict[str, Any],
         verifier_model: str,
@@ -1252,9 +1267,9 @@ def create_server(
                 "flagged": bool(report.get("flagged", True)),
                 "summary": dict(report.get("summary") or {}),
                 "details_sha256": hashlib.sha256(
-                    json.dumps(
-                        report.get("details") or [], sort_keys=True, default=str
-                    ).encode("utf-8")
+                    json.dumps(report.get("details") or [], sort_keys=True, default=str).encode(
+                        "utf-8"
+                    )
                 ).hexdigest(),
             },
             audit_sid=audit_sid,

--- a/src/berry/mcp_server.py
+++ b/src/berry/mcp_server.py
@@ -8,6 +8,7 @@ Approved MCP tools only:
 - start_run
 - load_run
 - get_deliverable
+- export_run_ledger
 - add_span
 - add_file_span
 - record_attempt
@@ -68,6 +69,9 @@ from .run_ledger import (
 )
 from .run_ledger import (
     evidence_tsv_path as _ledger_evidence_tsv_path,
+)
+from .run_ledger import (
+    export_run as _ledger_export_run,
 )
 from .run_ledger import (
     load_persisted_run as _ledger_load_persisted_run,
@@ -475,7 +479,7 @@ def create_server(
                     "ledger_path": str(_run_sqlite_path(run.run_id)),
                     "problem_sid": ps.sid,
                     "deliverable_sid": dv.sid,
-                    "schema_version": 3,
+                    "schema_version": 4,
                     "baseline_kind": run.baseline_kind,
                     "baseline_ref": run.baseline_ref,
                 }
@@ -532,6 +536,19 @@ def create_server(
                 "text": rec.text,
                 "meta": rec.meta,
             }
+
+    @mcp.tool()
+    def export_run_ledger(run_id: Optional[str] = None) -> Dict[str, Any]:
+        """Regenerate full JSON/TSV inspection exports from the authoritative SQLite ledger."""
+        with _redirect_stdout_to_stderr():
+            try:
+                run = store.get_run(run_id)
+                _persist_run(run)
+                return _ledger_export_run(run.run_id)
+            except EnforcementError as exc:
+                raise RuntimeError(str(exc))
+            except Exception as exc:
+                raise RuntimeError(f"Failed to export run ledger: {type(exc).__name__}: {exc}")
 
     # -----------------------------
     # Evidence spans
@@ -977,7 +994,7 @@ def create_server(
             run = store.get_run(run_id)
             return {
                 "run_id": run.run_id,
-                "schema_version": 3,
+                "schema_version": 4,
                 "spans": store.list_spans(
                     run=run,
                     limit=int(limit or 200),

--- a/src/berry/prompts.py
+++ b/src/berry/prompts.py
@@ -23,7 +23,7 @@ The job is not to produce a plausible answer. The job is to resolve the user's q
 ## Mandatory external state
 - Start or load a run before substantive work.
 - All evidence must be stored as real spans in the active run.
-- The run directory is the working memory: `run.json`, `evidence.tsv`, and `attempts.tsv`.
+- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`).
 - Before each iteration, re-read `list_spans` and `list_attempts`.
 - Record every evidence-gathering move, experiment, audit result, and downgrade in the attempt ledger. Negative results are evidence.
 
@@ -189,7 +189,7 @@ Move fast, but never let assumptions masquerade as facts. The prototype must eme
 ## Mandatory external state
 - Start or load a run before substantive work.
 - All requirements, constraints, repo context, benchmarks, and spike results must be stored as real spans in the active run.
-- The run directory is the working memory: `run.json`, `evidence.tsv`, and `attempts.tsv`.
+- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`).
 - Before each iteration, re-read `list_spans` and `list_attempts`.
 - Record every evidence-gathering action, spike, benchmark, architectural hypothesis, and downgrade in the attempt ledger.
 
@@ -279,7 +279,7 @@ This is the generalized form of the program-style experiment loop: baseline -> h
 ## Mandatory external state
 - Start or load a run before substantive work.
 - All evidence, measurements, benchmarks, logs, repros, and diffs must be stored as real spans in the active run.
-- The run directory is the working memory: `run.json`, `evidence.tsv`, and `attempts.tsv`.
+- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`).
 - Before each iteration, re-read `list_spans` and `list_attempts`.
 - Record every baseline, experiment, audit result, keep/discard decision, and revert in the attempt ledger.
 - If code or config changes are possible, note the starting git state before each attempt and record the post-attempt git state in the ledger.
@@ -387,7 +387,7 @@ The loop is the job. Do not replace it with a summary.
 ## Mandatory external state
 - Start or load a run before doing substantive work.
 - All evidence must be stored as real spans in the active run; do not reason from unrecorded evidence.
-- The run directory is the working memory: `run.json`, `evidence.tsv`, and `attempts.tsv`. Before each iteration, re-read the latest span list and attempt list.
+- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`). Before each iteration, re-read the latest span list and attempt list.
 - Record every experiment, patch attempt, audit outcome, and revert decision in the attempt ledger. Negative results are evidence, not noise.
 
 ## Invalid states (must not occur)
@@ -479,7 +479,7 @@ This workflow has two coupled loops: a pre-approval planning loop and a post-app
 ## Mandatory external state
 - Start or load a run before substantive work.
 - All evidence must be stored as real spans in the active run.
-- The run directory is the working memory: `run.json`, `evidence.tsv`, and `attempts.tsv`. Re-read `list_spans` and `list_attempts` before each iteration.
+- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`). Re-read `list_spans` and `list_attempts` before each iteration.
 - Record every planning iteration and every execution attempt in the attempt ledger.
 
 ## Invalid states (must not occur)

--- a/src/berry/prompts.py
+++ b/src/berry/prompts.py
@@ -23,7 +23,7 @@ The job is not to produce a plausible answer. The job is to resolve the user's q
 ## Mandatory external state
 - Start or load a run before substantive work.
 - All evidence must be stored as real spans in the active run.
-- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`).
+- The run directory is the working memory: `run.sqlite` as the source of truth; call `export_run_ledger` only when full JSON/TSV inspection exports are needed.
 - Before each iteration, re-read `list_spans` and `list_attempts`.
 - Record every evidence-gathering move, experiment, audit result, and downgrade in the attempt ledger. Negative results are evidence.
 
@@ -189,7 +189,7 @@ Move fast, but never let assumptions masquerade as facts. The prototype must eme
 ## Mandatory external state
 - Start or load a run before substantive work.
 - All requirements, constraints, repo context, benchmarks, and spike results must be stored as real spans in the active run.
-- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`).
+- The run directory is the working memory: `run.sqlite` as the source of truth; call `export_run_ledger` only when full JSON/TSV inspection exports are needed.
 - Before each iteration, re-read `list_spans` and `list_attempts`.
 - Record every evidence-gathering action, spike, benchmark, architectural hypothesis, and downgrade in the attempt ledger.
 
@@ -279,7 +279,7 @@ This is the generalized form of the program-style experiment loop: baseline -> h
 ## Mandatory external state
 - Start or load a run before substantive work.
 - All evidence, measurements, benchmarks, logs, repros, and diffs must be stored as real spans in the active run.
-- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`).
+- The run directory is the working memory: `run.sqlite` as the source of truth; call `export_run_ledger` only when full JSON/TSV inspection exports are needed.
 - Before each iteration, re-read `list_spans` and `list_attempts`.
 - Record every baseline, experiment, audit result, keep/discard decision, and revert in the attempt ledger.
 - If code or config changes are possible, note the starting git state before each attempt and record the post-attempt git state in the ledger.
@@ -387,7 +387,7 @@ The loop is the job. Do not replace it with a summary.
 ## Mandatory external state
 - Start or load a run before doing substantive work.
 - All evidence must be stored as real spans in the active run; do not reason from unrecorded evidence.
-- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`). Before each iteration, re-read the latest span list and attempt list.
+- The run directory is the working memory: `run.sqlite` as the source of truth; call `export_run_ledger` only when full JSON/TSV inspection exports are needed. Before each iteration, re-read the latest span list and attempt list.
 - Record every experiment, patch attempt, audit outcome, and revert decision in the attempt ledger. Negative results are evidence, not noise.
 
 ## Invalid states (must not occur)
@@ -479,7 +479,7 @@ This workflow has two coupled loops: a pre-approval planning loop and a post-app
 ## Mandatory external state
 - Start or load a run before substantive work.
 - All evidence must be stored as real spans in the active run.
-- The run directory is the working memory: `run.sqlite` plus the JSON/TSV exports (`run.json`, `evidence.tsv`, `attempts.tsv`, `claims.tsv`, `claim_evidence.tsv`, `audits.tsv`, `ledger_events.jsonl`). Re-read `list_spans` and `list_attempts` before each iteration.
+- The run directory is the working memory: `run.sqlite` as the source of truth; call `export_run_ledger` only when full JSON/TSV inspection exports are needed. Re-read `list_spans` and `list_attempts` before each iteration.
 - Record every planning iteration and every execution attempt in the attempt ledger.
 
 ## Invalid states (must not occur)

--- a/src/berry/run_ledger.py
+++ b/src/berry/run_ledger.py
@@ -7,7 +7,7 @@ import os
 import sqlite3
 import time
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from .enforcement import (
     AttemptRecord,
@@ -17,11 +17,23 @@ from .enforcement import (
     EnforcementError,
     RunState,
     SpanRecord,
+    clear_run_dirty,
+    mark_run_dirty,
 )
 from .paths import ensure_berry_home
 
-LEDGER_SCHEMA_VERSION = 3
-_SQLITE_USER_VERSION = 3
+LEDGER_SCHEMA_VERSION = 4
+_SQLITE_USER_VERSION = 4
+_TABLE_SPECS = {
+    "spans": ("sid", "span"),
+    "attempts": ("attempt_id", "attempt"),
+    "claims": ("cid", "claim"),
+    "claim_evidence_links": ("link_id", "claim/evidence link"),
+    "audits": ("audit_id", "audit"),
+}
+_EXPORT_MODE_ENV = "BERRY_LEDGER_EXPORT_MODE"
+_WRITE_CONNECTIONS: Dict[Tuple[int, str], sqlite3.Connection] = {}
+_SCHEMA_READY: set[Tuple[int, str]] = set()
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +62,10 @@ def run_json_path(run_id: str) -> Path:
 
 def run_sqlite_path(run_id: str) -> Path:
     return run_dir(run_id) / "run.sqlite"
+
+
+def ledger_head_path(run_id: str) -> Path:
+    return run_dir(run_id) / "ledger_head.json"
 
 
 def evidence_tsv_path(run_id: str) -> Path:
@@ -90,6 +106,14 @@ def atomic_write_text(path: Path, text: str) -> None:
             tmp.unlink()
         except FileNotFoundError:
             pass
+
+
+def _append_text_durable(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(text)
+        fh.flush()
+        os.fsync(fh.fileno())
 
 
 def _sha256_text(text: str) -> str:
@@ -171,9 +195,49 @@ def audit_to_payload(rec: AuditRecord) -> Dict[str, Any]:
     return rec.to_public_dict()
 
 
-def run_to_payload(run: RunState) -> Dict[str, Any]:
+def run_meta_to_payload(run: RunState) -> Dict[str, Any]:
+    """Small SQLite run payload committed on every hot write.
+
+    Child objects live in normalized tables.  Keeping this payload small is what
+    removes the previous O(n²) append behavior: adding S599 no longer requires
+    serializing S0..S598 into the authoritative ``runs`` row.
+    """
+
     return {
         "schema_version": LEDGER_SCHEMA_VERSION,
+        "payload_kind": "ledger_head",
+        "run_id": run.run_id,
+        "created_at": float(run.created_at),
+        "deliverable_sid": run.deliverable_sid,
+        "next_span_idx": int(run.next_span_idx),
+        "next_attempt_idx": int(run.next_attempt_idx),
+        "next_claim_idx": int(run.next_claim_idx),
+        "next_claim_link_idx": int(run.next_claim_link_idx),
+        "next_audit_idx": int(run.next_audit_idx),
+        "spans_version": int(run.spans_version),
+        "baseline_kind": run.baseline_kind,
+        "baseline_ref": run.baseline_ref,
+        "counts": {
+            "spans": len(run.spans),
+            "attempts": len(run.attempts),
+            "claims": len(run.claims),
+            "claim_evidence_links": len(run.claim_evidence_links),
+            "audits": len(run.audits),
+        },
+        "ledger": {
+            "source_of_truth": "run.sqlite",
+            "sqlite_schema_version": _SQLITE_USER_VERSION,
+            "integrity": "incremental_row_hash_event_chain",
+        },
+    }
+
+
+def run_to_payload(run: RunState) -> Dict[str, Any]:
+    """Full compatibility snapshot used for explicit/sync exports and legacy migration."""
+
+    return {
+        "schema_version": LEDGER_SCHEMA_VERSION,
+        "payload_kind": "full_export",
         "run_id": run.run_id,
         "created_at": float(run.created_at),
         "deliverable_sid": run.deliverable_sid,
@@ -217,7 +281,9 @@ def _bump_counter_from_ids(current: int, ids: Iterable[str], prefix: str) -> int
     return out
 
 
-def run_from_payload(raw: Dict[str, Any], *, fallback_run_id: Optional[str] = None) -> RunState:
+def run_from_payload(
+    raw: Dict[str, Any], *, fallback_run_id: Optional[str] = None, mark_clean: bool = True
+) -> RunState:
     rid = str(raw.get("run_id") or fallback_run_id or "").strip()
     if not rid:
         raise EnforcementError("Invalid persisted run: missing run_id")
@@ -394,9 +460,7 @@ def run_from_payload(raw: Dict[str, Any], *, fallback_run_id: Optional[str] = No
                 )
             )
     run.next_claim_link_idx = _bump_counter_from_ids(
-        run.next_claim_link_idx,
-        [link.link_id for link in run.claim_evidence_links],
-        "L",
+        run.next_claim_link_idx, [link.link_id for link in run.claim_evidence_links], "L"
     )
 
     audits_raw = raw.get("audits") or []
@@ -436,11 +500,15 @@ def run_from_payload(raw: Dict[str, Any], *, fallback_run_id: Optional[str] = No
     run.next_audit_idx = _bump_counter_from_ids(
         run.next_audit_idx, [audit.audit_id for audit in run.audits], "V"
     )
+    if mark_clean:
+        clear_run_dirty(run)
+    else:
+        mark_run_dirty(run, all=True)
     return run
 
 
 # ---------------------------------------------------------------------------
-# SQLite source-of-truth with tamper-evident snapshot events
+# SQLite source-of-truth with incremental tamper-evident events
 # ---------------------------------------------------------------------------
 
 
@@ -455,6 +523,45 @@ def _connect(path: Path) -> sqlite3.Connection:
     return con
 
 
+def _connect_for_write(path: Path) -> sqlite3.Connection:
+    key = (os.getpid(), str(path.resolve()))
+    con = _WRITE_CONNECTIONS.get(key)
+    if con is not None and not path.exists():
+        try:
+            con.close()
+        except Exception:
+            pass
+        _WRITE_CONNECTIONS.pop(key, None)
+        _SCHEMA_READY.discard(key)
+        con = None
+    if con is None:
+        con = _connect(path)
+        _WRITE_CONNECTIONS[key] = con
+    if key not in _SCHEMA_READY:
+        _ensure_schema(con)
+        _SCHEMA_READY.add(key)
+    return con
+
+
+def close_cached_connections() -> None:
+    for con in list(_WRITE_CONNECTIONS.values()):
+        try:
+            con.close()
+        except Exception:
+            pass
+    _WRITE_CONNECTIONS.clear()
+    _SCHEMA_READY.clear()
+
+
+def _table_columns(con: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in con.execute(f"PRAGMA table_info({table})")}
+
+
+def _ensure_column(con: sqlite3.Connection, table: str, column: str, ddl: str) -> None:
+    if column not in _table_columns(con, table):
+        con.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl}")
+
+
 def _ensure_schema(con: sqlite3.Connection) -> None:
     con.executescript(
         """
@@ -462,6 +569,7 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
             run_id TEXT PRIMARY KEY,
             payload_json TEXT NOT NULL,
             payload_sha256 TEXT NOT NULL,
+            head_event_hash TEXT NOT NULL DEFAULT '',
             created_at REAL NOT NULL,
             updated_at REAL NOT NULL
         );
@@ -470,6 +578,7 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
             sid TEXT NOT NULL,
             position INTEGER NOT NULL,
             payload_json TEXT NOT NULL,
+            payload_sha256 TEXT NOT NULL DEFAULT '',
             text_sha256 TEXT NOT NULL,
             eid TEXT NOT NULL,
             kind TEXT NOT NULL,
@@ -484,6 +593,7 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
             attempt_id TEXT NOT NULL,
             position INTEGER NOT NULL,
             payload_json TEXT NOT NULL,
+            payload_sha256 TEXT NOT NULL DEFAULT '',
             PRIMARY KEY (run_id, attempt_id),
             FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
         );
@@ -492,6 +602,7 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
             cid TEXT NOT NULL,
             position INTEGER NOT NULL,
             payload_json TEXT NOT NULL,
+            payload_sha256 TEXT NOT NULL DEFAULT '',
             kind TEXT NOT NULL,
             status TEXT NOT NULL,
             target REAL NOT NULL,
@@ -505,6 +616,7 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
             link_id TEXT NOT NULL,
             position INTEGER NOT NULL,
             payload_json TEXT NOT NULL,
+            payload_sha256 TEXT NOT NULL DEFAULT '',
             cid TEXT NOT NULL,
             sid TEXT NOT NULL,
             relation TEXT NOT NULL,
@@ -522,6 +634,7 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
             audit_id TEXT NOT NULL,
             position INTEGER NOT NULL,
             payload_json TEXT NOT NULL,
+            payload_sha256 TEXT NOT NULL DEFAULT '',
             kind TEXT NOT NULL,
             created_at REAL NOT NULL,
             evidence_pack_id TEXT NOT NULL,
@@ -543,9 +656,15 @@ def _ensure_schema(con: sqlite3.Connection) -> None:
             event_hash TEXT NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_ledger_events_run ON ledger_events(run_id, event_id);
-        PRAGMA user_version = 3;
+        PRAGMA user_version = 4;
         """
     )
+    # Existing schema-3 ledgers need additive columns.  Keep these ALTERs outside
+    # the CREATE block so repeated starts are cheap and migration is automatic.
+    _ensure_column(con, "runs", "head_event_hash", "TEXT NOT NULL DEFAULT ''")
+    for table in _TABLE_SPECS:
+        _ensure_column(con, table, "payload_sha256", "TEXT NOT NULL DEFAULT ''")
+    con.execute(f"PRAGMA user_version = {_SQLITE_USER_VERSION}")
 
 
 def _append_event(
@@ -556,7 +675,7 @@ def _append_event(
     object_type: str,
     object_id: str,
     payload: Dict[str, Any],
-) -> None:
+) -> Dict[str, Any]:
     payload_json = _json_dumps(payload)
     payload_sha = _sha256_text(payload_json)
     row = con.execute(
@@ -578,7 +697,7 @@ def _append_event(
             }
         )
     )
-    con.execute(
+    cur = con.execute(
         """
         INSERT INTO ledger_events(
             run_id, ts, event_type, object_type, object_id,
@@ -597,161 +716,914 @@ def _append_event(
             event_hash,
         ),
     )
-
-
-def _content_manifest(run: RunState) -> Dict[str, Any]:
-    payload = run_to_payload(run)
     return {
-        "schema_version": LEDGER_SCHEMA_VERSION,
-        "run_id": run.run_id,
-        "payload_sha256": _sha256_text(_json_dumps(payload)),
+        "event_id": int(cur.lastrowid or 0),
+        "run_id": run_id,
+        "ts": ts,
+        "event_type": event_type,
+        "object_type": object_type,
+        "object_id": object_id,
+        "payload": payload,
+        "payload_sha256": payload_sha,
+        "prev_event_hash": prev,
+        "event_hash": event_hash,
+    }
+
+
+def _counts(run: RunState) -> Dict[str, int]:
+    return {
         "spans": len(run.spans),
         "attempts": len(run.attempts),
         "claims": len(run.claims),
         "claim_evidence_links": len(run.claim_evidence_links),
         "audits": len(run.audits),
-        "spans_version": run.spans_version,
-        "span_text_hashes": {
-            sid: run.spans[sid].text_sha256 for sid in run.span_order if sid in run.spans
-        },
-        "claim_statuses": {
-            cid: run.claims[cid].status for cid in run.claim_order if cid in run.claims
-        },
-        "audit_ids": [audit.audit_id for audit in run.audits],
     }
 
 
-def _replace_table_rows(con: sqlite3.Connection, run: RunState, payload: Dict[str, Any]) -> None:
-    run_json = _json_dumps(payload)
+def _position_map(values: Iterable[str]) -> Dict[str, int]:
+    return {str(v): pos for pos, v in enumerate(values)}
+
+
+def _attempt_position_map(run: RunState) -> Dict[str, int]:
+    return {rec.attempt_id: pos for pos, rec in enumerate(run.attempts)}
+
+
+def _link_position_map(run: RunState) -> Dict[str, int]:
+    return {rec.link_id: pos for pos, rec in enumerate(run.claim_evidence_links)}
+
+
+def _audit_position_map(run: RunState) -> Dict[str, int]:
+    return {rec.audit_id: pos for pos, rec in enumerate(run.audits)}
+
+
+def _db_counts(con: sqlite3.Connection, run_id: str) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    for table in _TABLE_SPECS:
+        out[table] = int(
+            con.execute(f"SELECT COUNT(*) FROM {table} WHERE run_id = ?", (run_id,)).fetchone()[0]
+        )
+    return out
+
+
+def _run_row_exists(con: sqlite3.Connection, run_id: str) -> bool:
+    return con.execute("SELECT 1 FROM runs WHERE run_id = ?", (run_id,)).fetchone() is not None
+
+
+def _row_payload_sha(payload: Dict[str, Any]) -> Tuple[str, str]:
+    payload_json = _json_dumps(payload)
+    return payload_json, _sha256_text(payload_json)
+
+
+def _upsert_span(con: sqlite3.Connection, run: RunState, sid: str, position: int) -> Dict[str, Any]:
+    span = run.spans.get(sid)
+    if span is None:
+        con.execute("DELETE FROM spans WHERE run_id = ? AND sid = ?", (run.run_id, sid))
+        return {"table": "spans", "id": sid, "op": "delete"}
+    sp = span_to_payload(span)
+    payload_json, payload_sha = _row_payload_sha(sp)
+    con.execute(
+        """
+        INSERT INTO spans(
+            run_id, sid, position, payload_json, payload_sha256, text_sha256,
+            eid, kind, status, source_type
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id, sid) DO UPDATE SET
+            position=excluded.position,
+            payload_json=excluded.payload_json,
+            payload_sha256=excluded.payload_sha256,
+            text_sha256=excluded.text_sha256,
+            eid=excluded.eid,
+            kind=excluded.kind,
+            status=excluded.status,
+            source_type=excluded.source_type
+        """,
+        (
+            run.run_id,
+            span.sid,
+            position,
+            payload_json,
+            payload_sha,
+            span.text_sha256,
+            span.eid,
+            span.kind,
+            span.status,
+            span.source_type,
+        ),
+    )
+    return {
+        "table": "spans",
+        "id": sid,
+        "op": "upsert",
+        "payload_sha256": payload_sha,
+        "position": position,
+    }
+
+
+def _upsert_attempt(
+    con: sqlite3.Connection,
+    run: RunState,
+    attempt_id: str,
+    by_id: Dict[str, AttemptRecord],
+    position: int,
+) -> Dict[str, Any]:
+    rec = by_id.get(attempt_id)
+    if rec is None:
+        con.execute(
+            "DELETE FROM attempts WHERE run_id = ? AND attempt_id = ?", (run.run_id, attempt_id)
+        )
+        return {"table": "attempts", "id": attempt_id, "op": "delete"}
+    payload_json, payload_sha = _row_payload_sha(attempt_to_payload(rec))
+    con.execute(
+        """
+        INSERT INTO attempts(run_id, attempt_id, position, payload_json, payload_sha256)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(run_id, attempt_id) DO UPDATE SET
+            position=excluded.position,
+            payload_json=excluded.payload_json,
+            payload_sha256=excluded.payload_sha256
+        """,
+        (run.run_id, rec.attempt_id, position, payload_json, payload_sha),
+    )
+    return {
+        "table": "attempts",
+        "id": attempt_id,
+        "op": "upsert",
+        "payload_sha256": payload_sha,
+        "position": position,
+    }
+
+
+def _upsert_claim(
+    con: sqlite3.Connection, run: RunState, cid: str, position: int
+) -> Dict[str, Any]:
+    claim = run.claims.get(cid)
+    if claim is None:
+        con.execute("DELETE FROM claims WHERE run_id = ? AND cid = ?", (run.run_id, cid))
+        return {"table": "claims", "id": cid, "op": "delete"}
+    cp = claim_to_payload(claim)
+    payload_json, payload_sha = _row_payload_sha(cp)
+    con.execute(
+        """
+        INSERT INTO claims(
+            run_id, cid, position, payload_json, payload_sha256, kind, status, target, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id, cid) DO UPDATE SET
+            position=excluded.position,
+            payload_json=excluded.payload_json,
+            payload_sha256=excluded.payload_sha256,
+            kind=excluded.kind,
+            status=excluded.status,
+            target=excluded.target,
+            updated_at=excluded.updated_at
+        """,
+        (
+            run.run_id,
+            claim.cid,
+            position,
+            payload_json,
+            payload_sha,
+            claim.kind,
+            claim.status,
+            claim.target,
+            claim.updated_at,
+        ),
+    )
+    return {
+        "table": "claims",
+        "id": cid,
+        "op": "upsert",
+        "payload_sha256": payload_sha,
+        "position": position,
+    }
+
+
+def _upsert_link(
+    con: sqlite3.Connection,
+    run: RunState,
+    link_id: str,
+    by_id: Dict[str, ClaimEvidenceLink],
+    position: int,
+) -> Dict[str, Any]:
+    link = by_id.get(link_id)
+    if link is None:
+        con.execute(
+            "DELETE FROM claim_evidence_links WHERE run_id = ? AND link_id = ?",
+            (run.run_id, link_id),
+        )
+        return {"table": "claim_evidence_links", "id": link_id, "op": "delete"}
+    if link.cid not in run.claims or link.sid not in run.spans:
+        raise EnforcementError(
+            f"Cannot persist dangling claim/evidence link {link.link_id}: {link.cid}->{link.sid}"
+        )
+    lp = claim_evidence_to_payload(link)
+    payload_json, payload_sha = _row_payload_sha(lp)
+    con.execute(
+        """
+        INSERT INTO claim_evidence_links(
+            run_id, link_id, position, payload_json, payload_sha256, cid, sid, relation, audit_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id, link_id) DO UPDATE SET
+            position=excluded.position,
+            payload_json=excluded.payload_json,
+            payload_sha256=excluded.payload_sha256,
+            cid=excluded.cid,
+            sid=excluded.sid,
+            relation=excluded.relation,
+            audit_id=excluded.audit_id
+        """,
+        (
+            run.run_id,
+            link.link_id,
+            position,
+            payload_json,
+            payload_sha,
+            link.cid,
+            link.sid,
+            link.relation,
+            link.audit_id,
+        ),
+    )
+    return {
+        "table": "claim_evidence_links",
+        "id": link_id,
+        "op": "upsert",
+        "payload_sha256": payload_sha,
+        "position": position,
+    }
+
+
+def _upsert_audit(
+    con: sqlite3.Connection,
+    run: RunState,
+    audit_id: str,
+    by_id: Dict[str, AuditRecord],
+    position: int,
+) -> Dict[str, Any]:
+    audit = by_id.get(audit_id)
+    if audit is None:
+        con.execute("DELETE FROM audits WHERE run_id = ? AND audit_id = ?", (run.run_id, audit_id))
+        return {"table": "audits", "id": audit_id, "op": "delete"}
+    dangling_claims = [cid for cid in audit.claim_ids if cid not in run.claims]
+    dangling_sids = [
+        sid for sid in audit.input_sids + audit.materialized_sids if sid not in run.spans
+    ]
+    if dangling_claims or dangling_sids:
+        raise EnforcementError(
+            f"Cannot persist dangling audit {audit.audit_id}: claims={dangling_claims}, sids={dangling_sids}"
+        )
+    ap = audit_to_payload(audit)
+    payload_json, payload_sha = _row_payload_sha(ap)
+    con.execute(
+        """
+        INSERT INTO audits(
+            run_id, audit_id, position, payload_json, payload_sha256, kind, created_at,
+            evidence_pack_id, evidence_pack_hash
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id, audit_id) DO UPDATE SET
+            position=excluded.position,
+            payload_json=excluded.payload_json,
+            payload_sha256=excluded.payload_sha256,
+            kind=excluded.kind,
+            created_at=excluded.created_at,
+            evidence_pack_id=excluded.evidence_pack_id,
+            evidence_pack_hash=excluded.evidence_pack_hash
+        """,
+        (
+            run.run_id,
+            audit.audit_id,
+            position,
+            payload_json,
+            payload_sha,
+            audit.kind,
+            audit.created_at,
+            audit.evidence_pack_id,
+            audit.evidence_pack_hash,
+        ),
+    )
+    return {
+        "table": "audits",
+        "id": audit_id,
+        "op": "upsert",
+        "payload_sha256": payload_sha,
+        "position": position,
+    }
+
+
+def _delete_all_child_rows(con: sqlite3.Connection, run_id: str) -> None:
+    for table in ["claim_evidence_links", "audits", "attempts", "claims", "spans"]:
+        con.execute(f"DELETE FROM {table} WHERE run_id = ?", (run_id,))
+
+
+def _collect_and_apply_changes(
+    con: sqlite3.Connection, run: RunState, *, full_snapshot: bool
+) -> List[Dict[str, Any]]:
+    if full_snapshot:
+        _delete_all_child_rows(con, run.run_id)
+
+    span_pos = _position_map(run.span_order)
+    attempt_by_id = {rec.attempt_id: rec for rec in run.attempts}
+    attempt_pos = _attempt_position_map(run)
+    claim_pos = _position_map(run.claim_order)
+    link_by_id = {rec.link_id: rec for rec in run.claim_evidence_links}
+    link_pos = _link_position_map(run)
+    audit_by_id = {rec.audit_id: rec for rec in run.audits}
+    audit_pos = _audit_position_map(run)
+
+    if full_snapshot:
+        span_ids = list(run.span_order)
+        attempt_ids = [rec.attempt_id for rec in run.attempts]
+        claim_ids = list(run.claim_order)
+        link_ids = [rec.link_id for rec in run.claim_evidence_links]
+        audit_ids = [rec.audit_id for rec in run.audits]
+    else:
+        span_ids = sorted(run.ledger_dirty_spans, key=lambda sid: span_pos.get(sid, 10**12))
+        attempt_ids = sorted(
+            run.ledger_dirty_attempts, key=lambda aid: attempt_pos.get(aid, 10**12)
+        )
+        claim_ids = sorted(run.ledger_dirty_claims, key=lambda cid: claim_pos.get(cid, 10**12))
+        link_ids = sorted(run.ledger_dirty_claim_links, key=lambda lid: link_pos.get(lid, 10**12))
+        audit_ids = sorted(run.ledger_dirty_audits, key=lambda aid: audit_pos.get(aid, 10**12))
+
+    changes: List[Dict[str, Any]] = []
+    for sid in span_ids:
+        changes.append(_upsert_span(con, run, sid, span_pos.get(sid, -1)))
+    for attempt_id in attempt_ids:
+        changes.append(
+            _upsert_attempt(con, run, attempt_id, attempt_by_id, attempt_pos.get(attempt_id, -1))
+        )
+    for cid in claim_ids:
+        changes.append(_upsert_claim(con, run, cid, claim_pos.get(cid, -1)))
+    for link_id in link_ids:
+        changes.append(_upsert_link(con, run, link_id, link_by_id, link_pos.get(link_id, -1)))
+    for audit_id in audit_ids:
+        changes.append(_upsert_audit(con, run, audit_id, audit_by_id, audit_pos.get(audit_id, -1)))
+    return changes
+
+
+def _should_force_full(con: sqlite3.Connection, run: RunState) -> bool:
+    if bool(run.ledger_dirty_all):
+        return True
+    if not _run_row_exists(con, run.run_id):
+        return True
+    # This cheap count check catches direct append/delete mutations that bypassed
+    # RunStore's dirty sets.  Normal appends have explicit dirty child IDs and
+    # should remain O(1), even though the committed DB count is temporarily lower
+    # than the in-memory count until this transaction applies the new row.
+    has_child_dirty = bool(
+        run.ledger_dirty_spans
+        or run.ledger_dirty_attempts
+        or run.ledger_dirty_claims
+        or run.ledger_dirty_claim_links
+        or run.ledger_dirty_audits
+    )
+    if has_child_dirty:
+        return False
+    try:
+        return _db_counts(con, run.run_id) != _counts(run)
+    except Exception:
+        return True
+
+
+def _has_pending_dirty_rows(run: RunState) -> bool:
+    return bool(
+        run.ledger_dirty_all
+        or run.ledger_dirty_meta
+        or run.ledger_dirty_spans
+        or run.ledger_dirty_attempts
+        or run.ledger_dirty_claims
+        or run.ledger_dirty_claim_links
+        or run.ledger_dirty_audits
+    )
+
+
+def _dirty_ids_by_table(run: RunState) -> Dict[str, set[str]]:
+    return {
+        "spans": set(run.ledger_dirty_spans),
+        "attempts": set(run.ledger_dirty_attempts),
+        "claims": set(run.ledger_dirty_claims),
+        "claim_evidence_links": set(run.ledger_dirty_claim_links),
+        "audits": set(run.ledger_dirty_audits),
+    }
+
+
+def _current_run_row_hashes(run: RunState) -> Dict[str, Dict[str, str]]:
+    hashes: Dict[str, Dict[str, str]] = {table: {} for table in _TABLE_SPECS}
+    for sid, span in run.spans.items():
+        _payload_json, payload_sha = _row_payload_sha(span_to_payload(span))
+        hashes["spans"][sid] = payload_sha
+    for rec in run.attempts:
+        _payload_json, payload_sha = _row_payload_sha(attempt_to_payload(rec))
+        hashes["attempts"][rec.attempt_id] = payload_sha
+    for cid, claim in run.claims.items():
+        _payload_json, payload_sha = _row_payload_sha(claim_to_payload(claim))
+        hashes["claims"][cid] = payload_sha
+    for link in run.claim_evidence_links:
+        _payload_json, payload_sha = _row_payload_sha(claim_evidence_to_payload(link))
+        hashes["claim_evidence_links"][link.link_id] = payload_sha
+    for audit in run.audits:
+        _payload_json, payload_sha = _row_payload_sha(audit_to_payload(audit))
+        hashes["audits"][audit.audit_id] = payload_sha
+    return hashes
+
+
+def _install_committed_state(
+    run: RunState,
+    *,
+    head_event_hash: str,
+    run_meta_sha256: str,
+    row_hashes: Dict[str, Dict[str, str]],
+) -> None:
+    run.ledger_committed_head_event_hash = str(head_event_hash or "")
+    run.ledger_committed_run_meta_sha256 = str(run_meta_sha256 or "")
+    run.ledger_committed_row_hashes = {
+        table: {str(k): str(v) for k, v in (row_hashes.get(table) or {}).items()}
+        for table in _TABLE_SPECS
+    }
+
+
+def _install_committed_state_from_replay(run: RunState, replay: Dict[str, Any]) -> None:
+    expected = replay.get("expected_tables") or {}
+    row_hashes: Dict[str, Dict[str, str]] = {table: {} for table in _TABLE_SPECS}
+    for table in _TABLE_SPECS:
+        for object_id, item in (expected.get(table) or {}).items():
+            row_hashes[table][str(object_id)] = str(item.get("payload_sha256") or "")
+    _install_committed_state(
+        run,
+        head_event_hash=str(replay.get("head_event_hash") or ""),
+        run_meta_sha256=str(replay.get("run_meta_sha256") or ""),
+        row_hashes=row_hashes,
+    )
+
+
+def _install_committed_state_from_event(run: RunState, event: Dict[str, Any]) -> None:
+    if bool(event.get("full_snapshot")) or not run.ledger_committed_row_hashes:
+        row_hashes = _current_run_row_hashes(run)
+    else:
+        row_hashes = {
+            table: dict(run.ledger_committed_row_hashes.get(table) or {}) for table in _TABLE_SPECS
+        }
+        for change in event.get("changes") or []:
+            if not isinstance(change, dict):
+                continue
+            table = str(change.get("table") or "")
+            object_id = str(change.get("id") or "")
+            if table not in row_hashes or not object_id:
+                continue
+            if str(change.get("op") or "upsert") == "delete":
+                row_hashes[table].pop(object_id, None)
+            else:
+                row_hashes[table][object_id] = str(change.get("payload_sha256") or "")
+    _install_committed_state(
+        run,
+        head_event_hash=str(event.get("event_hash") or ""),
+        run_meta_sha256=str(event.get("run_meta_sha256") or ""),
+        row_hashes=row_hashes,
+    )
+
+
+def _validate_write_base(con: sqlite3.Connection, run: RunState) -> None:
+    """Fail closed if the on-disk base changed since this RunState was loaded.
+
+    This keeps hot writes O(number of dirty rows).  We do not replay the full
+    event log on every span append, but we do check the committed run head and
+    every row that this commit is about to overwrite/delete.  Full verification
+    still happens on load/export, where untouched-row tampering is detected by
+    replaying the event chain and comparing the normalized tables.
+    """
+
+    row = con.execute(
+        "SELECT payload_sha256, head_event_hash FROM runs WHERE run_id = ?",
+        (run.run_id,),
+    ).fetchone()
+    if row is None:
+        return
+    expected_head = str(run.ledger_committed_head_event_hash or "")
+    if expected_head and str(row["head_event_hash"] or "") != expected_head:
+        raise EnforcementError(
+            "SQLite ledger changed since this run was loaded; reload before writing"
+        )
+    expected_meta = str(run.ledger_committed_run_meta_sha256 or "")
+    if expected_meta and str(row["payload_sha256"] or "") != expected_meta:
+        raise EnforcementError(
+            "SQLite run metadata changed since this run was loaded; reload before writing"
+        )
+
+    dirty = _dirty_ids_by_table(run)
+    for table, (id_col, label) in _TABLE_SPECS.items():
+        expected_hashes = run.ledger_committed_row_hashes.get(table) or {}
+        ids = set(dirty.get(table) or set())
+        if run.ledger_dirty_all:
+            ids.update(expected_hashes.keys())
+        if not ids:
+            continue
+        placeholders = ",".join("?" for _ in ids)
+        rows = con.execute(
+            f"SELECT {id_col} AS object_id, payload_json, payload_sha256 FROM {table} "
+            f"WHERE run_id = ? AND {id_col} IN ({placeholders})",
+            (run.run_id, *sorted(ids)),
+        ).fetchall()
+        actual = {str(r["object_id"]): r for r in rows}
+        for object_id in sorted(ids):
+            expected_sha = str(expected_hashes.get(object_id) or "")
+            current = actual.get(object_id)
+            if expected_sha:
+                if current is None:
+                    raise EnforcementError(
+                        f"SQLite {label} row {object_id} was removed since this run was loaded"
+                    )
+                payload_json = str(current["payload_json"] or "")
+                stored_sha = str(current["payload_sha256"] or "")
+                if _sha256_text(payload_json) != stored_sha or stored_sha != expected_sha:
+                    raise EnforcementError(
+                        f"SQLite {label} row {object_id} changed since this run was loaded"
+                    )
+            elif current is not None and not run.ledger_dirty_all:
+                raise EnforcementError(
+                    f"SQLite {label} row {object_id} already exists; reload before writing"
+                )
+
+
+def _mark_dirty_from_db_diff(con: sqlite3.Connection, run: RunState) -> None:
+    """Detect unmarked direct RunState edits without slowing the normal hot path.
+
+    RunStore marks changed rows explicitly.  If a caller bypasses RunStore and
+    calls persist_run with an apparently clean run, we first verify the existing
+    SQLite ledger against the event log so external tampering cannot be silently
+    healed by an in-memory object. Only then do we diff the clean in-memory run
+    against the verified durable state.
+    """
+
+    replay = _verify_event_hash_chain_con(con, run.run_id)
+    if replay.get("saw_incremental"):
+        row = con.execute(
+            "SELECT payload_sha256, head_event_hash FROM runs WHERE run_id = ?",
+            (run.run_id,),
+        ).fetchone()
+        if row is None:
+            mark_run_dirty(run, all=True)
+            return
+        if str(row["head_event_hash"] or "") != str(replay.get("head_event_hash") or ""):
+            raise EnforcementError("SQLite ledger head event hash mismatch")
+        if str(row["payload_sha256"] or "") != str(replay.get("run_meta_sha256") or ""):
+            raise EnforcementError("SQLite ledger head event does not match run metadata")
+        _verify_tables_against_event_log(con, run_id=run.run_id, replay=replay)
+
+    span_pos = _position_map(run.span_order)
+    actual_spans = _table_hashes(con, table="spans", id_col="sid", run_id=run.run_id)
+    for sid, span in run.spans.items():
+        _payload_json, payload_sha = _row_payload_sha(span_to_payload(span))
+        expected = {"payload_sha256": payload_sha, "position": span_pos.get(sid, -1)}
+        if actual_spans.get(sid) != expected:
+            run.ledger_dirty_spans.add(sid)
+    for sid in set(actual_spans) - set(run.spans):
+        run.ledger_dirty_spans.add(sid)
+
+    attempt_pos = _attempt_position_map(run)
+    attempt_by_id = {rec.attempt_id: rec for rec in run.attempts}
+    actual_attempts = _table_hashes(con, table="attempts", id_col="attempt_id", run_id=run.run_id)
+    for attempt_id, rec in attempt_by_id.items():
+        _payload_json, payload_sha = _row_payload_sha(attempt_to_payload(rec))
+        expected = {"payload_sha256": payload_sha, "position": attempt_pos.get(attempt_id, -1)}
+        if actual_attempts.get(attempt_id) != expected:
+            run.ledger_dirty_attempts.add(attempt_id)
+    for attempt_id in set(actual_attempts) - set(attempt_by_id):
+        run.ledger_dirty_attempts.add(attempt_id)
+
+    claim_pos = _position_map(run.claim_order)
+    actual_claims = _table_hashes(con, table="claims", id_col="cid", run_id=run.run_id)
+    for cid, claim in run.claims.items():
+        _payload_json, payload_sha = _row_payload_sha(claim_to_payload(claim))
+        expected = {"payload_sha256": payload_sha, "position": claim_pos.get(cid, -1)}
+        if actual_claims.get(cid) != expected:
+            run.ledger_dirty_claims.add(cid)
+    for cid in set(actual_claims) - set(run.claims):
+        run.ledger_dirty_claims.add(cid)
+
+    link_pos = _link_position_map(run)
+    link_by_id = {rec.link_id: rec for rec in run.claim_evidence_links}
+    actual_links = _table_hashes(
+        con, table="claim_evidence_links", id_col="link_id", run_id=run.run_id
+    )
+    for link_id, link in link_by_id.items():
+        _payload_json, payload_sha = _row_payload_sha(claim_evidence_to_payload(link))
+        expected = {"payload_sha256": payload_sha, "position": link_pos.get(link_id, -1)}
+        if actual_links.get(link_id) != expected:
+            run.ledger_dirty_claim_links.add(link_id)
+    for link_id in set(actual_links) - set(link_by_id):
+        run.ledger_dirty_claim_links.add(link_id)
+
+    audit_pos = _audit_position_map(run)
+    audit_by_id = {rec.audit_id: rec for rec in run.audits}
+    actual_audits = _table_hashes(con, table="audits", id_col="audit_id", run_id=run.run_id)
+    for audit_id, audit in audit_by_id.items():
+        _payload_json, payload_sha = _row_payload_sha(audit_to_payload(audit))
+        expected = {"payload_sha256": payload_sha, "position": audit_pos.get(audit_id, -1)}
+        if actual_audits.get(audit_id) != expected:
+            run.ledger_dirty_audits.add(audit_id)
+    for audit_id in set(actual_audits) - set(audit_by_id):
+        run.ledger_dirty_audits.add(audit_id)
+
+    _meta_json, meta_sha = _row_payload_sha(run_meta_to_payload(run))
+    row = con.execute("SELECT payload_sha256 FROM runs WHERE run_id = ?", (run.run_id,)).fetchone()
+    if row is None or str(row["payload_sha256"] or "") != meta_sha:
+        run.ledger_dirty_meta = True
+
+
+def _commit_incremental(con: sqlite3.Connection, run: RunState) -> Dict[str, Any]:
+    full_snapshot = _should_force_full(con, run)
+    meta_payload = run_meta_to_payload(run)
+    meta_json, meta_sha = _row_payload_sha(meta_payload)
     now = time.time()
     con.execute(
         """
-        INSERT INTO runs(run_id, payload_json, payload_sha256, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO runs(run_id, payload_json, payload_sha256, head_event_hash, created_at, updated_at)
+        VALUES (?, ?, ?, '', ?, ?)
         ON CONFLICT(run_id) DO UPDATE SET
             payload_json=excluded.payload_json,
             payload_sha256=excluded.payload_sha256,
             created_at=excluded.created_at,
             updated_at=excluded.updated_at
         """,
-        (run.run_id, run_json, _sha256_text(run_json), float(run.created_at), now),
+        (run.run_id, meta_json, meta_sha, float(run.created_at), now),
     )
+    changes = _collect_and_apply_changes(con, run, full_snapshot=full_snapshot)
+    # Persist a commit event even for metadata-only commits.  No-op calls with a
+    # clean run are filtered before opening the transaction.
+    event_payload = {
+        "schema_version": LEDGER_SCHEMA_VERSION,
+        "format": "incremental_v1",
+        "run_id": run.run_id,
+        "run_meta_sha256": meta_sha,
+        "full_snapshot": bool(full_snapshot),
+        "changes": changes,
+        "counts": _counts(run),
+        "spans_version": int(run.spans_version),
+    }
+    event = _append_event(
+        con,
+        run_id=run.run_id,
+        event_type="state_committed",
+        object_type="run",
+        object_id=run.run_id,
+        payload=event_payload,
+    )
+    con.execute(
+        "UPDATE runs SET head_event_hash = ?, updated_at = ? WHERE run_id = ?",
+        (event["event_hash"], time.time(), run.run_id),
+    )
+    event["changes"] = changes
+    event["run_meta_sha256"] = meta_sha
+    event["full_snapshot"] = bool(full_snapshot)
+    return event
 
-    for table in ["claim_evidence_links", "audits", "attempts", "claims", "spans"]:
-        con.execute(f"DELETE FROM {table} WHERE run_id = ?", (run.run_id,))
 
-    for pos, sid in enumerate(run.span_order):
-        span = run.spans.get(sid)
-        if not span:
-            continue
-        sp = span_to_payload(span)
-        con.execute(
-            """
-            INSERT INTO spans(
-                run_id, sid, position, payload_json, text_sha256, eid, kind, status, source_type
+def _export_mode(value: Optional[str] = None) -> str:
+    raw = (
+        str(value if value is not None else os.environ.get(_EXPORT_MODE_ENV, "off")).strip().lower()
+    )
+    if raw in {"1", "true", "yes", "sync", "full"}:
+        return "sync"
+    if raw in {"0", "false", "no", "off", "none"}:
+        return "off"
+    return "hot"
+
+
+def persist_run(run: RunState, *, export_mode: Optional[str] = None) -> None:
+    """Persist a run using incremental SQLite commits plus lightweight exports.
+
+    Integrity is preserved without the previous full-snapshot-per-write cost:
+    each changed normalized row stores its own payload hash; each commit appends
+    a hash-chained event containing the changed row hashes and current metadata
+    hash; load reconstructs the expected table state by replaying the event log
+    and comparing it to the SQLite rows. Default commits write only SQLite.
+    Set ``BERRY_LEDGER_EXPORT_MODE=hot`` for append-only inspection mirrors or
+    ``BERRY_LEDGER_EXPORT_MODE=sync`` to regenerate
+    full JSON/TSV snapshots on every commit for legacy consumers.
+    """
+
+    try:
+        mode = _export_mode(export_mode)
+        db_path = run_sqlite_path(run.run_id)
+        event: Optional[Dict[str, Any]] = None
+        # If the run is clean, still check for a missing DB.  This happens when a
+        # caller loads an object from a legacy JSON file and asks to persist after
+        # deleting the SQLite ledger.
+        con = _connect_for_write(db_path)
+        try:
+            if not _has_pending_dirty_rows(run) and _run_row_exists(con, run.run_id):
+                _mark_dirty_from_db_diff(con, run)
+                if not _has_pending_dirty_rows(run):
+                    return
+            con.execute("BEGIN IMMEDIATE")
+            _validate_write_base(con, run)
+            event = _commit_incremental(con, run)
+            con.commit()
+            _install_committed_state_from_event(run, event)
+            clear_run_dirty(run)
+        except Exception:
+            try:
+                con.rollback()
+            except Exception:
+                pass
+            raise
+        if mode == "sync":
+            _write_full_exports(run)
+        elif mode == "hot":
+            assert event is not None
+            _write_hot_exports(run, event)
+    except EnforcementError:
+        raise
+    except Exception as exc:
+        raise EnforcementError(
+            f"Failed to persist run ledger: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Verification and loading
+# ---------------------------------------------------------------------------
+
+
+def _verify_event_hash_chain_con(con: sqlite3.Connection, run_id: str) -> Dict[str, Any]:
+    rows = con.execute(
+        """
+        SELECT event_id, run_id, ts, event_type, object_type, object_id,
+               payload_json, payload_sha256, prev_event_hash, event_hash
+        FROM ledger_events WHERE run_id = ? ORDER BY event_id ASC
+        """,
+        (run_id,),
+    ).fetchall()
+    prev = "GENESIS"
+    expected: Dict[str, Dict[str, Dict[str, Any]]] = {table: {} for table in _TABLE_SPECS}
+    latest_meta_sha = ""
+    saw_incremental = False
+    for row in rows:
+        payload_json = str(row["payload_json"] or "")
+        payload_sha = _sha256_text(payload_json)
+        if payload_sha != row["payload_sha256"]:
+            raise EnforcementError(f"Ledger event {row['event_id']} payload hash mismatch")
+        if str(row["prev_event_hash"] or "") != prev:
+            raise EnforcementError(f"Ledger event {row['event_id']} previous hash mismatch")
+        expected_event_hash = _sha256_text(
+            _json_dumps(
+                {
+                    "run_id": row["run_id"],
+                    "ts": float(row["ts"]),
+                    "event_type": row["event_type"],
+                    "object_type": row["object_type"],
+                    "object_id": row["object_id"],
+                    "payload_sha256": row["payload_sha256"],
+                    "prev_event_hash": row["prev_event_hash"],
+                }
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                run.run_id,
-                span.sid,
-                pos,
-                _json_dumps(sp),
-                span.text_sha256,
-                span.eid,
-                span.kind,
-                span.status,
-                span.source_type,
-            ),
         )
+        if expected_event_hash != row["event_hash"]:
+            raise EnforcementError(f"Ledger event {row['event_id']} event hash mismatch")
+        payload = _json_loads_object(payload_json, context=f"ledger_events.{row['event_id']}")
+        if payload.get("format") == "incremental_v1" or "changes" in payload:
+            saw_incremental = True
+            latest_meta_sha = str(payload.get("run_meta_sha256") or latest_meta_sha)
+            if bool(payload.get("full_snapshot")):
+                expected = {table: {} for table in _TABLE_SPECS}
+            for change in payload.get("changes") or []:
+                if not isinstance(change, dict):
+                    raise EnforcementError(f"Ledger event {row['event_id']} has invalid change")
+                table = str(change.get("table") or "")
+                object_id = str(change.get("id") or "")
+                if table not in expected or not object_id:
+                    raise EnforcementError(f"Ledger event {row['event_id']} has invalid table/id")
+                op = str(change.get("op") or "upsert")
+                if op == "delete":
+                    expected[table].pop(object_id, None)
+                    continue
+                if op != "upsert":
+                    raise EnforcementError(f"Ledger event {row['event_id']} has invalid op {op!r}")
+                payload_sha256 = str(change.get("payload_sha256") or "")
+                try:
+                    position = int(change["position"])
+                except Exception as exc:
+                    raise EnforcementError(
+                        f"Ledger event {row['event_id']} has invalid position"
+                    ) from exc
+                if not payload_sha256:
+                    raise EnforcementError(
+                        f"Ledger event {row['event_id']} missing row payload hash"
+                    )
+                expected[table][object_id] = {
+                    "payload_sha256": payload_sha256,
+                    "position": position,
+                }
+            counts = payload.get("counts")
+            if isinstance(counts, dict):
+                for table in _TABLE_SPECS:
+                    if table in counts and int(counts.get(table) or 0) != len(expected[table]):
+                        raise EnforcementError(
+                            f"Ledger event {row['event_id']} {table} count mismatch"
+                        )
+        prev = str(row["event_hash"])
+    return {
+        "events": len(rows),
+        "head_event_hash": None if not rows else prev,
+        "run_meta_sha256": latest_meta_sha,
+        "expected_tables": expected,
+        "saw_incremental": saw_incremental,
+    }
 
-    for pos, attempt in enumerate(run.attempts):
-        con.execute(
-            "INSERT INTO attempts(run_id, attempt_id, position, payload_json) VALUES (?, ?, ?, ?)",
-            (run.run_id, attempt.attempt_id, pos, _json_dumps(attempt_to_payload(attempt))),
-        )
 
-    for pos, cid in enumerate(run.claim_order):
-        claim = run.claims.get(cid)
-        if not claim:
-            continue
-        cp = claim_to_payload(claim)
-        con.execute(
-            """
-            INSERT INTO claims(
-                run_id, cid, position, payload_json, kind, status, target, updated_at
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                run.run_id,
-                claim.cid,
-                pos,
-                _json_dumps(cp),
-                claim.kind,
-                claim.status,
-                claim.target,
-                claim.updated_at,
-            ),
-        )
+def verify_event_hash_chain(path: Path, run_id: str) -> Dict[str, Any]:
+    """Verify the per-run event hash chain and replay incremental state hashes."""
 
-    for pos, link in enumerate(run.claim_evidence_links):
-        if link.cid not in run.claims or link.sid not in run.spans:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    with _connect(path) as con:
+        _ensure_schema(con)
+        return _verify_event_hash_chain_con(con, run_id)
+
+
+def _table_hashes(
+    con: sqlite3.Connection, *, table: str, id_col: str, run_id: str
+) -> Dict[str, Dict[str, Any]]:
+    rows = con.execute(
+        "SELECT "
+        f"{id_col} AS object_id, position, payload_json, payload_sha256 FROM {table} "
+        "WHERE run_id = ? ORDER BY position ASC",
+        (run_id,),
+    ).fetchall()
+    out: Dict[str, Dict[str, Any]] = {}
+    label = _TABLE_SPECS[table][1]
+    for row in rows:
+        object_id = str(row["object_id"])
+        payload_json = str(row["payload_json"] or "")
+        actual_sha = _sha256_text(payload_json)
+        stored_sha = str(row["payload_sha256"] or "")
+        if not stored_sha:
             raise EnforcementError(
-                "Cannot persist dangling claim/evidence link "
-                f"{link.link_id}: {link.cid}->{link.sid}"
+                f"SQLite {label} table is inconsistent with ledger event log: "
+                "missing row payload hash"
             )
-        lp = claim_evidence_to_payload(link)
-        con.execute(
-            """
-            INSERT INTO claim_evidence_links(
-                run_id, link_id, position, payload_json, cid, sid, relation, audit_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                run.run_id,
-                link.link_id,
-                pos,
-                _json_dumps(lp),
-                link.cid,
-                link.sid,
-                link.relation,
-                link.audit_id,
-            ),
-        )
-
-    for pos, audit in enumerate(run.audits):
-        dangling_claims = [cid for cid in audit.claim_ids if cid not in run.claims]
-        dangling_sids = [
-            sid for sid in audit.input_sids + audit.materialized_sids if sid not in run.spans
-        ]
-        if dangling_claims or dangling_sids:
+        if actual_sha != stored_sha:
             raise EnforcementError(
-                f"Cannot persist dangling audit {audit.audit_id}: "
-                f"claims={dangling_claims}, sids={dangling_sids}"
+                f"SQLite {label} table is inconsistent with ledger event log: payload hash mismatch"
             )
-        ap = audit_to_payload(audit)
-        con.execute(
-            """
-            INSERT INTO audits(
-                run_id, audit_id, position, payload_json, kind, created_at,
-                evidence_pack_id, evidence_pack_hash
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                run.run_id,
-                audit.audit_id,
-                pos,
-                _json_dumps(ap),
-                audit.kind,
-                audit.created_at,
-                audit.evidence_pack_id,
-                audit.evidence_pack_hash,
-            ),
-        )
+        out[object_id] = {"payload_sha256": stored_sha, "position": int(row["position"])}
+    return out
+
+
+def _verify_tables_against_event_log(
+    con: sqlite3.Connection, *, run_id: str, replay: Dict[str, Any]
+) -> None:
+    expected = replay.get("expected_tables") or {}
+    for table, (id_col, label) in _TABLE_SPECS.items():
+        actual = _table_hashes(con, table=table, id_col=id_col, run_id=run_id)
+        exp = expected.get(table) or {}
+        if actual != exp:
+            raise EnforcementError(f"SQLite {label} table is inconsistent with ledger event log")
 
 
 def _table_payloads(
+    con: sqlite3.Connection, *, table: str, id_col: str, run_id: str
+) -> List[Dict[str, Any]]:
+    rows = con.execute(
+        "SELECT "
+        f"{id_col} AS object_id, payload_json FROM {table} "
+        "WHERE run_id = ? ORDER BY position ASC",
+        (run_id,),
+    ).fetchall()
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        out.append(
+            _json_loads_object(
+                str(row["payload_json"] or "{}"), context=f"{table}.{row['object_id']}"
+            )
+        )
+    return out
+
+
+def _full_payload_from_sqlite(
+    con: sqlite3.Connection, *, run_id: str, meta_payload: Dict[str, Any]
+) -> Dict[str, Any]:
+    spans_list = _table_payloads(con, table="spans", id_col="sid", run_id=run_id)
+    attempts = _table_payloads(con, table="attempts", id_col="attempt_id", run_id=run_id)
+    claims_list = _table_payloads(con, table="claims", id_col="cid", run_id=run_id)
+    links = _table_payloads(con, table="claim_evidence_links", id_col="link_id", run_id=run_id)
+    audits = _table_payloads(con, table="audits", id_col="audit_id", run_id=run_id)
+    payload = dict(meta_payload)
+    payload["payload_kind"] = "full_from_sqlite"
+    payload["span_order"] = [str(item.get("sid")) for item in spans_list]
+    payload["claim_order"] = [str(item.get("cid") or item.get("claim_id")) for item in claims_list]
+    payload["spans"] = {str(item.get("sid")): item for item in spans_list}
+    payload["attempts"] = attempts
+    payload["claims"] = {str(item.get("cid") or item.get("claim_id")): item for item in claims_list}
+    payload["claim_evidence_links"] = links
+    payload["audits"] = audits
+    return payload
+
+
+# Legacy schema-3 verification.  Keep this code so already-created v3 ledgers
+# migrate safely rather than being trusted by shape alone.
+
+
+def _legacy_table_payloads(
     con: sqlite3.Connection, *, table: str, id_col: str, run_id: str
 ) -> Dict[str, Dict[str, Any]]:
     rows = con.execute(
@@ -768,20 +1640,18 @@ def _table_payloads(
     return out
 
 
-def _verify_normalized_tables(
+def _verify_legacy_normalized_tables(
     con: sqlite3.Connection, *, run_id: str, payload: Dict[str, Any]
 ) -> None:
-    """Ensure normalized SQLite tables have not drifted from the run payload."""
-
     expected_spans = dict(payload.get("spans") or {})
-    actual_spans = _table_payloads(con, table="spans", id_col="sid", run_id=run_id)
+    actual_spans = _legacy_table_payloads(con, table="spans", id_col="sid", run_id=run_id)
     if {k: _json_dumps(v) for k, v in actual_spans.items()} != {
         k: _json_dumps(v) for k, v in expected_spans.items()
     }:
         raise EnforcementError("SQLite span table is inconsistent with run payload")
 
     expected_claims = dict(payload.get("claims") or {})
-    actual_claims = _table_payloads(con, table="claims", id_col="cid", run_id=run_id)
+    actual_claims = _legacy_table_payloads(con, table="claims", id_col="cid", run_id=run_id)
     if {k: _json_dumps(v) for k, v in actual_claims.items()} != {
         k: _json_dumps(v) for k, v in expected_claims.items()
     }:
@@ -792,7 +1662,9 @@ def _verify_normalized_tables(
         for i, item in enumerate(payload.get("attempts") or [])
         if isinstance(item, dict)
     }
-    actual_attempts = _table_payloads(con, table="attempts", id_col="attempt_id", run_id=run_id)
+    actual_attempts = _legacy_table_payloads(
+        con, table="attempts", id_col="attempt_id", run_id=run_id
+    )
     if {k: _json_dumps(v) for k, v in actual_attempts.items()} != {
         k: _json_dumps(v) for k, v in expected_attempts.items()
     }:
@@ -803,7 +1675,7 @@ def _verify_normalized_tables(
         for i, item in enumerate(payload.get("claim_evidence_links") or [])
         if isinstance(item, dict)
     }
-    actual_links = _table_payloads(
+    actual_links = _legacy_table_payloads(
         con, table="claim_evidence_links", id_col="link_id", run_id=run_id
     )
     if {k: _json_dumps(v) for k, v in actual_links.items()} != {
@@ -816,18 +1688,16 @@ def _verify_normalized_tables(
         for i, item in enumerate(payload.get("audits") or [])
         if isinstance(item, dict)
     }
-    actual_audits = _table_payloads(con, table="audits", id_col="audit_id", run_id=run_id)
+    actual_audits = _legacy_table_payloads(con, table="audits", id_col="audit_id", run_id=run_id)
     if {k: _json_dumps(v) for k, v in actual_audits.items()} != {
         k: _json_dumps(v) for k, v in expected_audits.items()
     }:
         raise EnforcementError("SQLite audit table is inconsistent with run payload")
 
 
-def _verify_head_event_matches_payload(
+def _verify_legacy_head_event_matches_payload(
     con: sqlite3.Connection, *, run_id: str, payload_json: str
 ) -> None:
-    """Ensure the latest snapshot event commits the current run payload hash."""
-
     row = con.execute(
         """
         SELECT payload_json FROM ledger_events
@@ -839,8 +1709,7 @@ def _verify_head_event_matches_payload(
     if row is None:
         raise EnforcementError(f"SQLite ledger for run {run_id!r} has no snapshot event")
     event_payload = _json_loads_object(
-        str(row["payload_json"] or "{}"),
-        context="ledger_events.snapshot_committed.payload_json",
+        str(row["payload_json"] or "{}"), context="ledger_events.snapshot_committed.payload_json"
     )
     expected_payload_sha = str(event_payload.get("payload_sha256") or "")
     actual_payload_sha = _sha256_text(payload_json)
@@ -848,87 +1717,12 @@ def _verify_head_event_matches_payload(
         raise EnforcementError("SQLite ledger head event does not match run payload")
 
 
-def persist_run(run: RunState) -> None:
-    """Persist a run into SQLite source-of-truth plus inspection exports.
-
-    The SQLite write is a single IMMEDIATE transaction.  A tamper-evident
-    snapshot event is appended on every successful commit.  JSON/TSV files are
-    compatibility exports; they are not the source of truth once ``run.sqlite``
-    exists, but export failures still fail closed so users do not rely on stale
-    inspection ledgers.
-    """
-
-    try:
-        payload = run_to_payload(run)
-        db_path = run_sqlite_path(run.run_id)
-        with _connect(db_path) as con:
-            _ensure_schema(con)
-            con.execute("BEGIN IMMEDIATE")
-            _replace_table_rows(con, run, payload)
-            _append_event(
-                con,
-                run_id=run.run_id,
-                event_type="snapshot_committed",
-                object_type="run",
-                object_id=run.run_id,
-                payload=_content_manifest(run),
-            )
-            con.commit()
-        _write_exports(run, payload)
-    except EnforcementError:
-        raise
-    except Exception as exc:
-        raise EnforcementError(
-            f"Failed to persist run ledger: {type(exc).__name__}: {exc}"
-        ) from exc
-
-
-def verify_event_hash_chain(path: Path, run_id: str) -> Dict[str, Any]:
-    """Verify the per-run event hash chain and payload hashes."""
-
-    if not path.exists():
-        raise FileNotFoundError(path)
-    with _connect(path) as con:
-        _ensure_schema(con)
-        rows = con.execute(
-            """
-            SELECT event_id, run_id, ts, event_type, object_type, object_id,
-                   payload_json, payload_sha256, prev_event_hash, event_hash
-            FROM ledger_events WHERE run_id = ? ORDER BY event_id ASC
-            """,
-            (run_id,),
-        ).fetchall()
-    prev = "GENESIS"
-    for row in rows:
-        payload_sha = _sha256_text(str(row["payload_json"] or ""))
-        if payload_sha != row["payload_sha256"]:
-            raise EnforcementError(f"Ledger event {row['event_id']} payload hash mismatch")
-        if str(row["prev_event_hash"] or "") != prev:
-            raise EnforcementError(f"Ledger event {row['event_id']} previous hash mismatch")
-        expected = _sha256_text(
-            _json_dumps(
-                {
-                    "run_id": row["run_id"],
-                    "ts": float(row["ts"]),
-                    "event_type": row["event_type"],
-                    "object_type": row["object_type"],
-                    "object_id": row["object_id"],
-                    "payload_sha256": row["payload_sha256"],
-                    "prev_event_hash": row["prev_event_hash"],
-                }
-            )
-        )
-        if expected != row["event_hash"]:
-            raise EnforcementError(f"Ledger event {row['event_id']} event hash mismatch")
-        prev = str(row["event_hash"])
-    return {"events": len(rows), "head_event_hash": None if not rows else prev}
-
-
 def _load_from_sqlite(path: Path, run_id: str) -> RunState:
+    needs_migration = False
     with _connect(path) as con:
         _ensure_schema(con)
         row = con.execute(
-            "SELECT payload_json, payload_sha256 FROM runs WHERE run_id = ?",
+            "SELECT payload_json, payload_sha256, head_event_hash FROM runs WHERE run_id = ?",
             (run_id,),
         ).fetchone()
         if row is None:
@@ -937,15 +1731,42 @@ def _load_from_sqlite(path: Path, run_id: str) -> RunState:
         if _sha256_text(payload_json) != str(row["payload_sha256"] or ""):
             raise EnforcementError(f"Run payload hash mismatch in {path}")
         payload = _json_loads_object(payload_json, context=f"{path}:runs.payload_json")
-        _verify_normalized_tables(con, run_id=run_id, payload=payload)
-        _verify_head_event_matches_payload(con, run_id=run_id, payload_json=payload_json)
-    verify_event_hash_chain(path, run_id)
-    return run_from_payload(payload, fallback_run_id=run_id)
+
+        if "spans" in payload or payload.get("payload_kind") == "full_export":
+            # Schema-3 full-payload ledger. Verify using the old cross-table and
+            # head-event checks, then migrate to incremental v4 after closing the DB.
+            _verify_legacy_normalized_tables(con, run_id=run_id, payload=payload)
+            _verify_legacy_head_event_matches_payload(con, run_id=run_id, payload_json=payload_json)
+            _verify_event_hash_chain_con(con, run_id)
+            run = run_from_payload(payload, fallback_run_id=run_id, mark_clean=False)
+            needs_migration = True
+        else:
+            replay = _verify_event_hash_chain_con(con, run_id)
+            if not replay.get("saw_incremental"):
+                raise EnforcementError(
+                    f"SQLite ledger for run {run_id!r} has no incremental state events"
+                )
+            if str(row["head_event_hash"] or "") != str(replay.get("head_event_hash") or ""):
+                raise EnforcementError("SQLite ledger head event hash mismatch")
+            if str(row["payload_sha256"] or "") != str(replay.get("run_meta_sha256") or ""):
+                raise EnforcementError("SQLite ledger head event does not match run metadata")
+            _verify_tables_against_event_log(con, run_id=run_id, replay=replay)
+            full_payload = _full_payload_from_sqlite(con, run_id=run_id, meta_payload=payload)
+            run = run_from_payload(full_payload, fallback_run_id=run_id, mark_clean=True)
+            _install_committed_state_from_replay(run, replay)
+    if needs_migration:
+        persist_run(run)
+    return run
 
 
 def _load_from_json(path: Path, run_id: str) -> RunState:
     raw = _json_loads_object(path.read_text(encoding="utf-8"), context=str(path))
-    return run_from_payload(raw, fallback_run_id=run_id)
+    if raw.get("payload_kind") == "ledger_head" and not raw.get("spans"):
+        raise EnforcementError(
+            f"{path} is a lightweight SQLite ledger head export, not a recoverable JSON run. "
+            "Restore run.sqlite or enable BERRY_LEDGER_EXPORT_MODE=sync for full JSON exports."
+        )
+    return run_from_payload(raw, fallback_run_id=run_id, mark_clean=False)
 
 
 def load_persisted_run(run_id: str) -> RunState:
@@ -958,10 +1779,8 @@ def load_persisted_run(run_id: str) -> RunState:
     json_path = run_json_path(rid)
     if json_path.exists():
         run = _load_from_json(json_path, rid)
-        # JSON-only runs are legacy compatibility input.  Migrate them into
-        # the SQLite ledger immediately so subsequent loads get hash-chain
-        # verification and normalized graph tables.  Fail closed if the
-        # migration cannot be committed.
+        # JSON-only runs are legacy compatibility input.  Migrate them into the
+        # SQLite ledger immediately.  Fail closed if migration cannot be committed.
         persist_run(run)
         return run
     raise FileNotFoundError(run_dir(rid))
@@ -972,18 +1791,320 @@ def load_persisted_run(run_id: str) -> RunState:
 # ---------------------------------------------------------------------------
 
 
-def _write_exports(run: RunState, payload: Dict[str, Any]) -> None:
+def _write_hot_exports(run: RunState, event: Dict[str, Any]) -> None:
+    """Write O(1) inspection artifacts for the latest commit.
+
+    These files are not the source of truth; SQLite is.  They intentionally avoid
+    full-run rewrites on each span append.  Use ``BERRY_LEDGER_EXPORT_MODE=sync``
+    to regenerate the legacy full snapshots.
+    """
+
+    head = {
+        "schema_version": LEDGER_SCHEMA_VERSION,
+        "payload_kind": "ledger_head",
+        "run_id": run.run_id,
+        "source_of_truth": "run.sqlite",
+        "ledger_path": str(run_sqlite_path(run.run_id)),
+        "head_event_hash": event["event_hash"],
+        "last_event_id": event["event_id"],
+        "last_event_type": event["event_type"],
+        "run_meta_sha256": event["run_meta_sha256"],
+        "full_snapshot": event["full_snapshot"],
+        "counts": _counts(run),
+        "spans_version": int(run.spans_version),
+        "updated_at": time.time(),
+        "exports": {
+            "mode": "hot",
+            "description": "Lightweight head and append-only TSV/JSONL mirrors; run.sqlite is authoritative.",
+            "sync_mode": f"Set {_EXPORT_MODE_ENV}=sync to regenerate full JSON/TSV snapshots on every commit.",
+        },
+    }
+    text = json.dumps(head, indent=2, sort_keys=True) + "\n"
+    atomic_write_text(run_json_path(run.run_id), text)
+    atomic_write_text(ledger_head_path(run.run_id), text)
+    _append_event_jsonl(run.run_id, event)
+    _append_changed_tsv_rows(run, event.get("changes") or [], int(event["event_id"]))
+
+
+def _append_event_jsonl(run_id: str, event: Dict[str, Any]) -> None:
+    row = {
+        "event_id": event["event_id"],
+        "run_id": event["run_id"],
+        "ts": event["ts"],
+        "event_type": event["event_type"],
+        "object_type": event["object_type"],
+        "object_id": event["object_id"],
+        "payload_sha256": event["payload_sha256"],
+        "prev_event_hash": event["prev_event_hash"],
+        "event_hash": event["event_hash"],
+        "payload": event["payload"],
+    }
+    _append_text_durable(ledger_events_jsonl_path(run_id), json.dumps(row, sort_keys=True) + "\n")
+
+
+def _ensure_tsv_header(path: Path, header: List[str]) -> None:
+    if path.exists() and path.stat().st_size > 0:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh, delimiter="\t")
+        writer.writerow(header)
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def _append_tsv_rows(path: Path, header: List[str], rows: List[List[Any]]) -> None:
+    if not rows:
+        _ensure_tsv_header(path, header)
+        return
+    _ensure_tsv_header(path, header)
+    with path.open("a", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh, delimiter="\t")
+        writer.writerows(rows)
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def _append_changed_tsv_rows(run: RunState, changes: List[Dict[str, Any]], event_id: int) -> None:
+    by_table: Dict[str, List[str]] = {table: [] for table in _TABLE_SPECS}
+    for change in changes:
+        if change.get("op") != "upsert":
+            continue
+        table = str(change.get("table") or "")
+        object_id = str(change.get("id") or "")
+        if table in by_table and object_id:
+            by_table[table].append(object_id)
+
+    evidence_rows: List[List[Any]] = []
+    for sid in by_table["spans"]:
+        rec = run.spans.get(sid)
+        if not rec:
+            continue
+        locator = ""
+        if rec.locator:
+            path_val = rec.locator.get("path") or rec.locator.get("rel_path") or ""
+            start = rec.locator.get("start_line", "")
+            end = rec.locator.get("end_line", "")
+            locator = f"{path_val}:{start}-{end}" if path_val else json.dumps(rec.locator)
+        evidence_rows.append(
+            [
+                event_id,
+                f"{float(rec.created_at):.6f}",
+                run.run_id,
+                rec.sid,
+                rec.eid,
+                rec.source,
+                rec.source_type,
+                rec.kind,
+                rec.trust,
+                rec.status,
+                rec.sensitivity,
+                locator,
+                ",".join(rec.parents),
+                rec.text_sha256,
+                len(rec.text),
+                rec.preview(limit=200, redact_sensitive=True),
+            ]
+        )
+    _append_tsv_rows(
+        evidence_tsv_path(run.run_id),
+        [
+            "event_id",
+            "ts",
+            "run_id",
+            "sid",
+            "eid",
+            "source",
+            "source_type",
+            "kind",
+            "trust",
+            "status",
+            "sensitivity",
+            "locator",
+            "parents",
+            "text_sha256",
+            "chars",
+            "preview",
+        ],
+        evidence_rows,
+    )
+
+    attempt_by_id = {rec.attempt_id: rec for rec in run.attempts}
+    _append_tsv_rows(
+        attempts_tsv_path(run.run_id),
+        [
+            "event_id",
+            "ts",
+            "run_id",
+            "attempt_id",
+            "claim_id",
+            "hypothesis",
+            "action",
+            "budget_minutes",
+            "input_sids",
+            "output_sids",
+            "audit_status",
+            "decision",
+            "next_step",
+        ],
+        [
+            [
+                event_id,
+                f"{float(rec.created_at):.6f}",
+                run.run_id,
+                rec.attempt_id,
+                rec.claim_id,
+                rec.hypothesis,
+                rec.action,
+                f"{float(rec.budget_minutes):.2f}",
+                ",".join(rec.input_sids),
+                ",".join(rec.output_sids),
+                rec.audit_status,
+                rec.decision,
+                rec.next_step,
+            ]
+            for aid in by_table["attempts"]
+            for rec in [attempt_by_id.get(aid)]
+            if rec is not None
+        ],
+    )
+
+    _append_tsv_rows(
+        claims_tsv_path(run.run_id),
+        [
+            "event_id",
+            "ts",
+            "run_id",
+            "cid",
+            "kind",
+            "status",
+            "target",
+            "latest_audit_id",
+            "evidence_sids",
+            "claim",
+        ],
+        [
+            [
+                event_id,
+                f"{float(rec.created_at):.6f}",
+                run.run_id,
+                rec.cid,
+                rec.kind,
+                rec.status,
+                f"{float(rec.target):.4f}",
+                rec.latest_audit_id,
+                ",".join(link.sid for link in run.claim_evidence_links if link.cid == rec.cid),
+                rec.text,
+            ]
+            for cid in by_table["claims"]
+            for rec in [run.claims.get(cid)]
+            if rec is not None
+        ],
+    )
+
+    link_by_id = {rec.link_id: rec for rec in run.claim_evidence_links}
+    _append_tsv_rows(
+        claim_evidence_tsv_path(run.run_id),
+        [
+            "event_id",
+            "ts",
+            "run_id",
+            "link_id",
+            "cid",
+            "sid",
+            "relation",
+            "audit_id",
+            "created_by",
+            "note",
+        ],
+        [
+            [
+                event_id,
+                f"{float(rec.created_at):.6f}",
+                run.run_id,
+                rec.link_id,
+                rec.cid,
+                rec.sid,
+                rec.relation,
+                rec.audit_id,
+                rec.created_by,
+                rec.note,
+            ]
+            for lid in by_table["claim_evidence_links"]
+            for rec in [link_by_id.get(lid)]
+            if rec is not None
+        ],
+    )
+
+    audit_by_id = {rec.audit_id: rec for rec in run.audits}
+    _append_tsv_rows(
+        audits_tsv_path(run.run_id),
+        [
+            "event_id",
+            "ts",
+            "run_id",
+            "audit_id",
+            "kind",
+            "claim_ids",
+            "input_sids",
+            "materialized_sids",
+            "evidence_pack_id",
+            "evidence_pack_hash",
+            "audit_sid",
+        ],
+        [
+            [
+                event_id,
+                f"{float(rec.created_at):.6f}",
+                run.run_id,
+                rec.audit_id,
+                rec.kind,
+                ",".join(rec.claim_ids),
+                ",".join(rec.input_sids),
+                ",".join(rec.materialized_sids),
+                rec.evidence_pack_id,
+                rec.evidence_pack_hash,
+                rec.audit_sid,
+            ]
+            for aid in by_table["audits"]
+            for rec in [audit_by_id.get(aid)]
+            if rec is not None
+        ],
+    )
+
+
+def _write_full_exports(run: RunState) -> None:
+    payload = run_to_payload(run)
     run_json = json.dumps(payload, indent=2, sort_keys=True) + "\n"
     atomic_write_text(run_json_path(run.run_id), run_json)
+    atomic_write_text(ledger_head_path(run.run_id), run_json)
     _write_evidence_tsv(run)
     _write_attempts_tsv(run)
     _write_claims_tsv(run)
     _write_claim_evidence_tsv(run)
     _write_audits_tsv(run)
-    _write_ledger_events_jsonl(run.run_id)
+    _write_ledger_events_jsonl_snapshot(run.run_id)
 
 
-def _write_ledger_events_jsonl(run_id: str) -> None:
+def export_run(run_id: str) -> Dict[str, Any]:
+    """Regenerate full JSON/TSV inspection exports from the authoritative ledger."""
+
+    run = load_persisted_run(run_id)
+    _write_full_exports(run)
+    return {
+        "run_id": run.run_id,
+        "mode": "sync",
+        "run_json": str(run_json_path(run.run_id)),
+        "evidence_tsv": str(evidence_tsv_path(run.run_id)),
+        "attempts_tsv": str(attempts_tsv_path(run.run_id)),
+        "claims_tsv": str(claims_tsv_path(run.run_id)),
+        "claim_evidence_tsv": str(claim_evidence_tsv_path(run.run_id)),
+        "audits_tsv": str(audits_tsv_path(run.run_id)),
+        "ledger_events_jsonl": str(ledger_events_jsonl_path(run.run_id)),
+    }
+
+
+def _write_ledger_events_jsonl_snapshot(run_id: str) -> None:
     path = ledger_events_jsonl_path(run_id)
     rows: List[Dict[str, Any]] = []
     with _connect(run_sqlite_path(run_id)) as con:
@@ -1008,12 +2129,14 @@ def _write_ledger_events_jsonl(run_id: str) -> None:
                     "prev_event_hash": row["prev_event_hash"],
                     "event_hash": row["event_hash"],
                     "payload": _json_loads_object(
-                        row["payload_json"],
-                        context=f"{path}:ledger_events.payload_json",
+                        row["payload_json"], context=f"{path}:ledger_events.payload_json"
                     ),
                 }
             )
     atomic_write_text(path, "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
+
+
+# Full TSV snapshot writers, used only by explicit/sync exports.
 
 
 def _write_evidence_tsv(run: RunState) -> None:
@@ -1070,6 +2193,8 @@ def _write_evidence_tsv(run: RunState) -> None:
                         rec.preview(limit=200, redact_sensitive=True),
                     ]
                 )
+            fh.flush()
+            os.fsync(fh.fileno())
         os.replace(tmp, path)
     finally:
         try:
@@ -1117,6 +2242,8 @@ def _write_attempts_tsv(run: RunState) -> None:
                         rec.next_step,
                     ]
                 )
+            fh.flush()
+            os.fsync(fh.fileno())
         os.replace(tmp, path)
     finally:
         try:
@@ -1162,6 +2289,8 @@ def _write_claims_tsv(run: RunState) -> None:
                         rec.text,
                     ]
                 )
+            fh.flush()
+            os.fsync(fh.fileno())
         os.replace(tmp, path)
     finally:
         try:
@@ -1203,6 +2332,8 @@ def _write_claim_evidence_tsv(run: RunState) -> None:
                         rec.note,
                     ]
                 )
+            fh.flush()
+            os.fsync(fh.fileno())
         os.replace(tmp, path)
     finally:
         try:
@@ -1246,6 +2377,8 @@ def _write_audits_tsv(run: RunState) -> None:
                         rec.audit_sid,
                     ]
                 )
+            fh.flush()
+            os.fsync(fh.fileno())
         os.replace(tmp, path)
     finally:
         try:

--- a/src/berry/run_ledger.py
+++ b/src/berry/run_ledger.py
@@ -235,7 +235,7 @@ def run_from_payload(raw: Dict[str, Any], *, fallback_run_id: Optional[str] = No
 
     spans_raw = raw.get("spans") or {}
     if isinstance(spans_raw, dict):
-        span_iter = spans_raw.items()
+        span_iter: Iterable[tuple[str, Any]] = spans_raw.items()
     elif isinstance(spans_raw, list):
         span_iter = [
             (str(rec.get("sid") or f"S{i}"), rec)
@@ -305,14 +305,10 @@ def run_from_payload(raw: Dict[str, Any], *, fallback_run_id: Optional[str] = No
                     action=str(rec.get("action") or ""),
                     budget_minutes=float(rec.get("budget_minutes") or 0.0),
                     input_sids=[
-                        str(v).strip()
-                        for v in (rec.get("input_sids") or [])
-                        if str(v).strip()
+                        str(v).strip() for v in (rec.get("input_sids") or []) if str(v).strip()
                     ],
                     output_sids=[
-                        str(v).strip()
-                        for v in (rec.get("output_sids") or [])
-                        if str(v).strip()
+                        str(v).strip() for v in (rec.get("output_sids") or []) if str(v).strip()
                     ],
                     audit_status=str(rec.get("audit_status") or ""),
                     decision=str(rec.get("decision") or ""),
@@ -329,7 +325,7 @@ def run_from_payload(raw: Dict[str, Any], *, fallback_run_id: Optional[str] = No
 
     claims_raw = raw.get("claims") or {}
     if isinstance(claims_raw, dict):
-        claim_iter = claims_raw.items()
+        claim_iter: Iterable[tuple[str, Any]] = claims_raw.items()
     elif isinstance(claims_raw, list):
         claim_iter = [
             (str(rec.get("cid") or rec.get("claim_id") or f"C{i}"), rec)

--- a/src/berry/run_ledger.py
+++ b/src/berry/run_ledger.py
@@ -1,0 +1,1258 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .enforcement import (
+    AttemptRecord,
+    AuditRecord,
+    ClaimEvidenceLink,
+    ClaimRecord,
+    EnforcementError,
+    RunState,
+    SpanRecord,
+)
+from .paths import ensure_berry_home
+
+LEDGER_SCHEMA_VERSION = 3
+_SQLITE_USER_VERSION = 3
+
+
+# ---------------------------------------------------------------------------
+# Paths and durable file helpers
+# ---------------------------------------------------------------------------
+
+
+def runs_dir() -> Path:
+    d = ensure_berry_home() / "runs"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def run_dir(run_id: str) -> Path:
+    rid = str(run_id or "").strip()
+    if not rid:
+        raise EnforcementError("run_id is required")
+    d = runs_dir() / rid
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def run_json_path(run_id: str) -> Path:
+    return run_dir(run_id) / "run.json"
+
+
+def run_sqlite_path(run_id: str) -> Path:
+    return run_dir(run_id) / "run.sqlite"
+
+
+def evidence_tsv_path(run_id: str) -> Path:
+    return run_dir(run_id) / "evidence.tsv"
+
+
+def attempts_tsv_path(run_id: str) -> Path:
+    return run_dir(run_id) / "attempts.tsv"
+
+
+def claims_tsv_path(run_id: str) -> Path:
+    return run_dir(run_id) / "claims.tsv"
+
+
+def claim_evidence_tsv_path(run_id: str) -> Path:
+    return run_dir(run_id) / "claim_evidence.tsv"
+
+
+def audits_tsv_path(run_id: str) -> Path:
+    return run_dir(run_id) / "audits.tsv"
+
+
+def ledger_events_jsonl_path(run_id: str) -> Path:
+    return run_dir(run_id) / "ledger_events.jsonl"
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{time.time_ns()}")
+    try:
+        with tmp.open("w", encoding="utf-8") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(str(text or "").encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def _json_loads_object(raw: str, *, context: str) -> Dict[str, Any]:
+    try:
+        value = json.loads(raw or "{}")
+    except Exception as exc:
+        raise EnforcementError(f"Invalid JSON in {context}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise EnforcementError(f"Invalid JSON in {context}: expected object")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+def span_to_payload(rec: SpanRecord) -> Dict[str, Any]:
+    transform = dict(rec.transform or {}) if isinstance(rec.transform, dict) else rec.transform
+    return {
+        "sid": rec.sid,
+        "text": rec.text,
+        "source": rec.source,
+        "created_at": float(rec.created_at),
+        "meta": dict(rec.meta or {}),
+        "eid": rec.eid,
+        "kind": rec.kind,
+        "source_type": rec.source_type,
+        "media_type": rec.media_type,
+        "text_sha256": rec.text_sha256,
+        "locator": dict(rec.locator or {}),
+        "snapshot": dict(rec.snapshot or {}),
+        "parents": list(rec.parents or []),
+        "transform": transform,
+        "trust": rec.trust,
+        "status": rec.status,
+        "sensitivity": rec.sensitivity,
+        "tags": list(rec.tags or []),
+    }
+
+
+def attempt_to_payload(rec: AttemptRecord) -> Dict[str, Any]:
+    return {
+        "attempt_id": rec.attempt_id,
+        "created_at": float(rec.created_at),
+        "claim_id": rec.claim_id,
+        "hypothesis": rec.hypothesis,
+        "action": rec.action,
+        "budget_minutes": float(rec.budget_minutes),
+        "input_sids": list(rec.input_sids),
+        "output_sids": list(rec.output_sids),
+        "audit_status": rec.audit_status,
+        "decision": rec.decision,
+        "git_state": rec.git_state,
+        "objective_metric": rec.objective_metric,
+        "objective_value": rec.objective_value,
+        "result_summary": rec.result_summary,
+        "next_step": rec.next_step,
+    }
+
+
+def claim_to_payload(rec: ClaimRecord) -> Dict[str, Any]:
+    return rec.to_public_dict()
+
+
+def claim_evidence_to_payload(rec: ClaimEvidenceLink) -> Dict[str, Any]:
+    return rec.to_public_dict()
+
+
+def audit_to_payload(rec: AuditRecord) -> Dict[str, Any]:
+    return rec.to_public_dict()
+
+
+def run_to_payload(run: RunState) -> Dict[str, Any]:
+    return {
+        "schema_version": LEDGER_SCHEMA_VERSION,
+        "run_id": run.run_id,
+        "created_at": float(run.created_at),
+        "deliverable_sid": run.deliverable_sid,
+        "next_span_idx": int(run.next_span_idx),
+        "next_attempt_idx": int(run.next_attempt_idx),
+        "next_claim_idx": int(run.next_claim_idx),
+        "next_claim_link_idx": int(run.next_claim_link_idx),
+        "next_audit_idx": int(run.next_audit_idx),
+        "spans_version": int(run.spans_version),
+        "baseline_kind": run.baseline_kind,
+        "baseline_ref": run.baseline_ref,
+        "span_order": list(run.span_order),
+        "claim_order": list(run.claim_order),
+        "spans": {sid: span_to_payload(rec) for sid, rec in run.spans.items()},
+        "attempts": [attempt_to_payload(rec) for rec in run.attempts],
+        "claims": {cid: claim_to_payload(rec) for cid, rec in run.claims.items()},
+        "claim_evidence_links": [
+            claim_evidence_to_payload(rec) for rec in run.claim_evidence_links
+        ],
+        "audits": [audit_to_payload(rec) for rec in run.audits],
+        "ledger": {
+            "source_of_truth": "run.sqlite",
+            "sqlite_schema_version": _SQLITE_USER_VERSION,
+        },
+    }
+
+
+def _numeric_suffix(identifier: str, prefix: str) -> Optional[int]:
+    value = str(identifier or "").strip()
+    if value.startswith(prefix) and value[len(prefix) :].isdigit():
+        return int(value[len(prefix) :])
+    return None
+
+
+def _bump_counter_from_ids(current: int, ids: Iterable[str], prefix: str) -> int:
+    out = int(current or 0)
+    for identifier in ids:
+        suffix = _numeric_suffix(identifier, prefix)
+        if suffix is not None:
+            out = max(out, suffix + 1)
+    return out
+
+
+def run_from_payload(raw: Dict[str, Any], *, fallback_run_id: Optional[str] = None) -> RunState:
+    rid = str(raw.get("run_id") or fallback_run_id or "").strip()
+    if not rid:
+        raise EnforcementError("Invalid persisted run: missing run_id")
+
+    run = RunState(run_id=rid, created_at=float(raw.get("created_at") or time.time()))
+    run.deliverable_sid = raw.get("deliverable_sid")
+    run.next_span_idx = int(raw.get("next_span_idx") or 0)
+    run.next_attempt_idx = int(raw.get("next_attempt_idx") or 0)
+    run.next_claim_idx = int(raw.get("next_claim_idx") or 0)
+    run.next_claim_link_idx = int(raw.get("next_claim_link_idx") or 0)
+    run.next_audit_idx = int(raw.get("next_audit_idx") or 0)
+    run.spans_version = int(raw.get("spans_version") or 0)
+    run.baseline_kind = str(raw.get("baseline_kind") or "fs")
+    run.baseline_ref = raw.get("baseline_ref")
+
+    spans_raw = raw.get("spans") or {}
+    if isinstance(spans_raw, dict):
+        span_iter = spans_raw.items()
+    elif isinstance(spans_raw, list):
+        span_iter = [
+            (str(rec.get("sid") or f"S{i}"), rec)
+            for i, rec in enumerate(spans_raw)
+            if isinstance(rec, dict)
+        ]
+    else:
+        span_iter = []
+    for sid, rec in span_iter:
+        if not isinstance(rec, dict):
+            continue
+        s = SpanRecord(
+            sid=str(rec.get("sid") or sid),
+            text=str(rec.get("text") or ""),
+            source=str(rec.get("source") or rec.get("source_type") or "manual"),
+            created_at=float(rec.get("created_at") or time.time()),
+            meta=dict(rec.get("meta") or {}),
+            eid=str(rec.get("eid") or ""),
+            kind=str(rec.get("kind") or ""),
+            source_type=str(rec.get("source_type") or rec.get("source") or "manual"),
+            media_type=str(rec.get("media_type") or "text/plain"),
+            text_sha256=str(rec.get("text_sha256") or ""),
+            locator=dict(rec.get("locator") or {}),
+            snapshot=dict(rec.get("snapshot") or {}),
+            parents=[str(v).strip() for v in (rec.get("parents") or []) if str(v).strip()],
+            transform=(
+                dict(rec.get("transform") or {})
+                if isinstance(rec.get("transform"), dict)
+                else rec.get("transform")
+            ),
+            trust=str(rec.get("trust") or ""),
+            status=str(rec.get("status") or "active"),
+            sensitivity=str(rec.get("sensitivity") or "unknown"),
+            tags=[str(v).strip() for v in (rec.get("tags") or []) if str(v).strip()],
+        )
+        if s.text.strip():
+            run.spans[s.sid] = s
+
+    order = raw.get("span_order")
+    if isinstance(order, list):
+        run.span_order = [str(x) for x in order if str(x) in run.spans]
+    else:
+        run.span_order = sorted(
+            run.spans.keys(),
+            key=lambda sid: (
+                _numeric_suffix(sid, "S") is None,
+                _numeric_suffix(sid, "S") or 0,
+                sid,
+            ),
+        )
+    for sid in run.spans:
+        if sid not in run.span_order:
+            run.span_order.append(sid)
+    run.next_span_idx = _bump_counter_from_ids(run.next_span_idx, run.spans.keys(), "S")
+
+    attempts_raw = raw.get("attempts") or []
+    if isinstance(attempts_raw, list):
+        for rec in attempts_raw:
+            if not isinstance(rec, dict):
+                continue
+            run.attempts.append(
+                AttemptRecord(
+                    attempt_id=str(rec.get("attempt_id") or f"A{len(run.attempts)}"),
+                    created_at=float(rec.get("created_at") or time.time()),
+                    claim_id=str(rec.get("claim_id") or ""),
+                    hypothesis=str(rec.get("hypothesis") or ""),
+                    action=str(rec.get("action") or ""),
+                    budget_minutes=float(rec.get("budget_minutes") or 0.0),
+                    input_sids=[
+                        str(v).strip()
+                        for v in (rec.get("input_sids") or [])
+                        if str(v).strip()
+                    ],
+                    output_sids=[
+                        str(v).strip()
+                        for v in (rec.get("output_sids") or [])
+                        if str(v).strip()
+                    ],
+                    audit_status=str(rec.get("audit_status") or ""),
+                    decision=str(rec.get("decision") or ""),
+                    git_state=str(rec.get("git_state") or ""),
+                    objective_metric=str(rec.get("objective_metric") or ""),
+                    objective_value=str(rec.get("objective_value") or ""),
+                    result_summary=str(rec.get("result_summary") or ""),
+                    next_step=str(rec.get("next_step") or ""),
+                )
+            )
+    run.next_attempt_idx = _bump_counter_from_ids(
+        run.next_attempt_idx, [a.attempt_id for a in run.attempts], "A"
+    )
+
+    claims_raw = raw.get("claims") or {}
+    if isinstance(claims_raw, dict):
+        claim_iter = claims_raw.items()
+    elif isinstance(claims_raw, list):
+        claim_iter = [
+            (str(rec.get("cid") or rec.get("claim_id") or f"C{i}"), rec)
+            for i, rec in enumerate(claims_raw)
+            if isinstance(rec, dict)
+        ]
+    else:
+        claim_iter = []
+    for cid, rec in claim_iter:
+        if not isinstance(rec, dict):
+            continue
+        text = str(rec.get("text") or rec.get("claim") or "").strip()
+        if not text:
+            continue
+        c = ClaimRecord(
+            cid=str(rec.get("cid") or rec.get("claim_id") or cid),
+            text=text,
+            kind=str(rec.get("kind") or "fact"),
+            status=str(rec.get("status") or "open"),
+            target=float(rec.get("target") or rec.get("confidence") or 0.95),
+            created_at=float(rec.get("created_at") or time.time()),
+            updated_at=float(rec.get("updated_at") or rec.get("created_at") or time.time()),
+            source=str(rec.get("source") or "manual"),
+            latest_audit_id=str(rec.get("latest_audit_id") or ""),
+            tags=[str(v).strip() for v in (rec.get("tags") or []) if str(v).strip()],
+            meta=dict(rec.get("meta") or {}),
+        )
+        run.claims[c.cid] = c
+    claim_order = raw.get("claim_order")
+    if isinstance(claim_order, list):
+        run.claim_order = [str(x) for x in claim_order if str(x) in run.claims]
+    else:
+        run.claim_order = sorted(
+            run.claims.keys(),
+            key=lambda cid: (
+                _numeric_suffix(cid, "C") is None,
+                _numeric_suffix(cid, "C") or 0,
+                cid,
+            ),
+        )
+    for cid in run.claims:
+        if cid not in run.claim_order:
+            run.claim_order.append(cid)
+    run.next_claim_idx = _bump_counter_from_ids(run.next_claim_idx, run.claims.keys(), "C")
+
+    links_raw = raw.get("claim_evidence_links") or raw.get("claim_links") or []
+    if isinstance(links_raw, list):
+        for rec in links_raw:
+            if not isinstance(rec, dict):
+                continue
+            cid = str(rec.get("cid") or rec.get("claim_id") or "").strip()
+            sid = str(rec.get("sid") or "").strip()
+            if cid not in run.claims or sid not in run.spans:
+                continue
+            run.claim_evidence_links.append(
+                ClaimEvidenceLink(
+                    link_id=str(rec.get("link_id") or f"L{len(run.claim_evidence_links)}"),
+                    cid=cid,
+                    sid=sid,
+                    relation=str(rec.get("relation") or "supports"),
+                    created_at=float(rec.get("created_at") or time.time()),
+                    created_by=str(rec.get("created_by") or "manual"),
+                    audit_id=str(rec.get("audit_id") or ""),
+                    note=str(rec.get("note") or ""),
+                    meta=dict(rec.get("meta") or {}),
+                )
+            )
+    run.next_claim_link_idx = _bump_counter_from_ids(
+        run.next_claim_link_idx,
+        [link.link_id for link in run.claim_evidence_links],
+        "L",
+    )
+
+    audits_raw = raw.get("audits") or []
+    if isinstance(audits_raw, list):
+        for rec in audits_raw:
+            if not isinstance(rec, dict):
+                continue
+            run.audits.append(
+                AuditRecord(
+                    audit_id=str(rec.get("audit_id") or f"V{len(run.audits)}"),
+                    kind=str(rec.get("kind") or "manual"),
+                    created_at=float(rec.get("created_at") or time.time()),
+                    claim_ids=[
+                        str(v).strip()
+                        for v in (rec.get("claim_ids") or [])
+                        if str(v).strip() in run.claims
+                    ],
+                    input_sids=[
+                        str(v).strip()
+                        for v in (rec.get("input_sids") or [])
+                        if str(v).strip() in run.spans
+                    ],
+                    materialized_sids=[
+                        str(v).strip()
+                        for v in (rec.get("materialized_sids") or [])
+                        if str(v).strip() in run.spans
+                    ],
+                    evidence_pack_id=str(rec.get("evidence_pack_id") or ""),
+                    evidence_pack_hash=str(rec.get("evidence_pack_hash") or ""),
+                    verifier_model=str(rec.get("verifier_model") or ""),
+                    policy=dict(rec.get("policy") or {}),
+                    result=dict(rec.get("result") or {}),
+                    audit_sid=str(rec.get("audit_sid") or ""),
+                    meta=dict(rec.get("meta") or {}),
+                )
+            )
+    run.next_audit_idx = _bump_counter_from_ids(
+        run.next_audit_idx, [audit.audit_id for audit in run.audits], "V"
+    )
+    return run
+
+
+# ---------------------------------------------------------------------------
+# SQLite source-of-truth with tamper-evident snapshot events
+# ---------------------------------------------------------------------------
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(path), timeout=30.0)
+    con.row_factory = sqlite3.Row
+    con.execute("PRAGMA busy_timeout=30000")
+    con.execute("PRAGMA foreign_keys=ON")
+    con.execute("PRAGMA journal_mode=WAL")
+    con.execute("PRAGMA synchronous=NORMAL")
+    return con
+
+
+def _ensure_schema(con: sqlite3.Connection) -> None:
+    con.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS runs (
+            run_id TEXT PRIMARY KEY,
+            payload_json TEXT NOT NULL,
+            payload_sha256 TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS spans (
+            run_id TEXT NOT NULL,
+            sid TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            payload_json TEXT NOT NULL,
+            text_sha256 TEXT NOT NULL,
+            eid TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            status TEXT NOT NULL,
+            source_type TEXT NOT NULL,
+            PRIMARY KEY (run_id, sid),
+            FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_spans_run_kind_status ON spans(run_id, kind, status);
+        CREATE TABLE IF NOT EXISTS attempts (
+            run_id TEXT NOT NULL,
+            attempt_id TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            payload_json TEXT NOT NULL,
+            PRIMARY KEY (run_id, attempt_id),
+            FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+        );
+        CREATE TABLE IF NOT EXISTS claims (
+            run_id TEXT NOT NULL,
+            cid TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            payload_json TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            status TEXT NOT NULL,
+            target REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            PRIMARY KEY (run_id, cid),
+            FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_claims_run_status ON claims(run_id, status, kind);
+        CREATE TABLE IF NOT EXISTS claim_evidence_links (
+            run_id TEXT NOT NULL,
+            link_id TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            payload_json TEXT NOT NULL,
+            cid TEXT NOT NULL,
+            sid TEXT NOT NULL,
+            relation TEXT NOT NULL,
+            audit_id TEXT NOT NULL,
+            PRIMARY KEY (run_id, link_id),
+            FOREIGN KEY (run_id, cid) REFERENCES claims(run_id, cid) ON DELETE CASCADE,
+            FOREIGN KEY (run_id, sid) REFERENCES spans(run_id, sid) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_claim_links_claim
+            ON claim_evidence_links(run_id, cid, relation);
+        CREATE INDEX IF NOT EXISTS idx_claim_links_span
+            ON claim_evidence_links(run_id, sid, relation);
+        CREATE TABLE IF NOT EXISTS audits (
+            run_id TEXT NOT NULL,
+            audit_id TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            payload_json TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            evidence_pack_id TEXT NOT NULL,
+            evidence_pack_hash TEXT NOT NULL,
+            PRIMARY KEY (run_id, audit_id),
+            FOREIGN KEY (run_id) REFERENCES runs(run_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_audits_run_kind ON audits(run_id, kind, created_at);
+        CREATE TABLE IF NOT EXISTS ledger_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id TEXT NOT NULL,
+            ts REAL NOT NULL,
+            event_type TEXT NOT NULL,
+            object_type TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            payload_sha256 TEXT NOT NULL,
+            prev_event_hash TEXT NOT NULL,
+            event_hash TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_ledger_events_run ON ledger_events(run_id, event_id);
+        PRAGMA user_version = 3;
+        """
+    )
+
+
+def _append_event(
+    con: sqlite3.Connection,
+    *,
+    run_id: str,
+    event_type: str,
+    object_type: str,
+    object_id: str,
+    payload: Dict[str, Any],
+) -> None:
+    payload_json = _json_dumps(payload)
+    payload_sha = _sha256_text(payload_json)
+    row = con.execute(
+        "SELECT event_hash FROM ledger_events WHERE run_id = ? ORDER BY event_id DESC LIMIT 1",
+        (run_id,),
+    ).fetchone()
+    prev = str(row["event_hash"] if row else "GENESIS")
+    ts = time.time()
+    event_hash = _sha256_text(
+        _json_dumps(
+            {
+                "run_id": run_id,
+                "ts": ts,
+                "event_type": event_type,
+                "object_type": object_type,
+                "object_id": object_id,
+                "payload_sha256": payload_sha,
+                "prev_event_hash": prev,
+            }
+        )
+    )
+    con.execute(
+        """
+        INSERT INTO ledger_events(
+            run_id, ts, event_type, object_type, object_id,
+            payload_json, payload_sha256, prev_event_hash, event_hash
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            run_id,
+            ts,
+            event_type,
+            object_type,
+            object_id,
+            payload_json,
+            payload_sha,
+            prev,
+            event_hash,
+        ),
+    )
+
+
+def _content_manifest(run: RunState) -> Dict[str, Any]:
+    payload = run_to_payload(run)
+    return {
+        "schema_version": LEDGER_SCHEMA_VERSION,
+        "run_id": run.run_id,
+        "payload_sha256": _sha256_text(_json_dumps(payload)),
+        "spans": len(run.spans),
+        "attempts": len(run.attempts),
+        "claims": len(run.claims),
+        "claim_evidence_links": len(run.claim_evidence_links),
+        "audits": len(run.audits),
+        "spans_version": run.spans_version,
+        "span_text_hashes": {
+            sid: run.spans[sid].text_sha256 for sid in run.span_order if sid in run.spans
+        },
+        "claim_statuses": {
+            cid: run.claims[cid].status for cid in run.claim_order if cid in run.claims
+        },
+        "audit_ids": [audit.audit_id for audit in run.audits],
+    }
+
+
+def _replace_table_rows(con: sqlite3.Connection, run: RunState, payload: Dict[str, Any]) -> None:
+    run_json = _json_dumps(payload)
+    now = time.time()
+    con.execute(
+        """
+        INSERT INTO runs(run_id, payload_json, payload_sha256, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(run_id) DO UPDATE SET
+            payload_json=excluded.payload_json,
+            payload_sha256=excluded.payload_sha256,
+            created_at=excluded.created_at,
+            updated_at=excluded.updated_at
+        """,
+        (run.run_id, run_json, _sha256_text(run_json), float(run.created_at), now),
+    )
+
+    for table in ["claim_evidence_links", "audits", "attempts", "claims", "spans"]:
+        con.execute(f"DELETE FROM {table} WHERE run_id = ?", (run.run_id,))
+
+    for pos, sid in enumerate(run.span_order):
+        span = run.spans.get(sid)
+        if not span:
+            continue
+        sp = span_to_payload(span)
+        con.execute(
+            """
+            INSERT INTO spans(
+                run_id, sid, position, payload_json, text_sha256, eid, kind, status, source_type
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run.run_id,
+                span.sid,
+                pos,
+                _json_dumps(sp),
+                span.text_sha256,
+                span.eid,
+                span.kind,
+                span.status,
+                span.source_type,
+            ),
+        )
+
+    for pos, attempt in enumerate(run.attempts):
+        con.execute(
+            "INSERT INTO attempts(run_id, attempt_id, position, payload_json) VALUES (?, ?, ?, ?)",
+            (run.run_id, attempt.attempt_id, pos, _json_dumps(attempt_to_payload(attempt))),
+        )
+
+    for pos, cid in enumerate(run.claim_order):
+        claim = run.claims.get(cid)
+        if not claim:
+            continue
+        cp = claim_to_payload(claim)
+        con.execute(
+            """
+            INSERT INTO claims(
+                run_id, cid, position, payload_json, kind, status, target, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run.run_id,
+                claim.cid,
+                pos,
+                _json_dumps(cp),
+                claim.kind,
+                claim.status,
+                claim.target,
+                claim.updated_at,
+            ),
+        )
+
+    for pos, link in enumerate(run.claim_evidence_links):
+        if link.cid not in run.claims or link.sid not in run.spans:
+            raise EnforcementError(
+                "Cannot persist dangling claim/evidence link "
+                f"{link.link_id}: {link.cid}->{link.sid}"
+            )
+        lp = claim_evidence_to_payload(link)
+        con.execute(
+            """
+            INSERT INTO claim_evidence_links(
+                run_id, link_id, position, payload_json, cid, sid, relation, audit_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run.run_id,
+                link.link_id,
+                pos,
+                _json_dumps(lp),
+                link.cid,
+                link.sid,
+                link.relation,
+                link.audit_id,
+            ),
+        )
+
+    for pos, audit in enumerate(run.audits):
+        dangling_claims = [cid for cid in audit.claim_ids if cid not in run.claims]
+        dangling_sids = [
+            sid for sid in audit.input_sids + audit.materialized_sids if sid not in run.spans
+        ]
+        if dangling_claims or dangling_sids:
+            raise EnforcementError(
+                f"Cannot persist dangling audit {audit.audit_id}: "
+                f"claims={dangling_claims}, sids={dangling_sids}"
+            )
+        ap = audit_to_payload(audit)
+        con.execute(
+            """
+            INSERT INTO audits(
+                run_id, audit_id, position, payload_json, kind, created_at,
+                evidence_pack_id, evidence_pack_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run.run_id,
+                audit.audit_id,
+                pos,
+                _json_dumps(ap),
+                audit.kind,
+                audit.created_at,
+                audit.evidence_pack_id,
+                audit.evidence_pack_hash,
+            ),
+        )
+
+
+def _table_payloads(
+    con: sqlite3.Connection, *, table: str, id_col: str, run_id: str
+) -> Dict[str, Dict[str, Any]]:
+    rows = con.execute(
+        "SELECT "
+        f"{id_col} AS object_id, payload_json FROM {table} "
+        "WHERE run_id = ? ORDER BY position ASC",
+        (run_id,),
+    ).fetchall()
+    out: Dict[str, Dict[str, Any]] = {}
+    for row in rows:
+        out[str(row["object_id"])] = _json_loads_object(
+            str(row["payload_json"] or "{}"), context=f"{table}.{row['object_id']}"
+        )
+    return out
+
+
+def _verify_normalized_tables(
+    con: sqlite3.Connection, *, run_id: str, payload: Dict[str, Any]
+) -> None:
+    """Ensure normalized SQLite tables have not drifted from the run payload."""
+
+    expected_spans = dict(payload.get("spans") or {})
+    actual_spans = _table_payloads(con, table="spans", id_col="sid", run_id=run_id)
+    if {k: _json_dumps(v) for k, v in actual_spans.items()} != {
+        k: _json_dumps(v) for k, v in expected_spans.items()
+    }:
+        raise EnforcementError("SQLite span table is inconsistent with run payload")
+
+    expected_claims = dict(payload.get("claims") or {})
+    actual_claims = _table_payloads(con, table="claims", id_col="cid", run_id=run_id)
+    if {k: _json_dumps(v) for k, v in actual_claims.items()} != {
+        k: _json_dumps(v) for k, v in expected_claims.items()
+    }:
+        raise EnforcementError("SQLite claim table is inconsistent with run payload")
+
+    expected_attempts = {
+        str(item.get("attempt_id") or f"A{i}"): item
+        for i, item in enumerate(payload.get("attempts") or [])
+        if isinstance(item, dict)
+    }
+    actual_attempts = _table_payloads(con, table="attempts", id_col="attempt_id", run_id=run_id)
+    if {k: _json_dumps(v) for k, v in actual_attempts.items()} != {
+        k: _json_dumps(v) for k, v in expected_attempts.items()
+    }:
+        raise EnforcementError("SQLite attempt table is inconsistent with run payload")
+
+    expected_links = {
+        str(item.get("link_id") or f"L{i}"): item
+        for i, item in enumerate(payload.get("claim_evidence_links") or [])
+        if isinstance(item, dict)
+    }
+    actual_links = _table_payloads(
+        con, table="claim_evidence_links", id_col="link_id", run_id=run_id
+    )
+    if {k: _json_dumps(v) for k, v in actual_links.items()} != {
+        k: _json_dumps(v) for k, v in expected_links.items()
+    }:
+        raise EnforcementError("SQLite claim/evidence link table is inconsistent with run payload")
+
+    expected_audits = {
+        str(item.get("audit_id") or f"V{i}"): item
+        for i, item in enumerate(payload.get("audits") or [])
+        if isinstance(item, dict)
+    }
+    actual_audits = _table_payloads(con, table="audits", id_col="audit_id", run_id=run_id)
+    if {k: _json_dumps(v) for k, v in actual_audits.items()} != {
+        k: _json_dumps(v) for k, v in expected_audits.items()
+    }:
+        raise EnforcementError("SQLite audit table is inconsistent with run payload")
+
+
+def _verify_head_event_matches_payload(
+    con: sqlite3.Connection, *, run_id: str, payload_json: str
+) -> None:
+    """Ensure the latest snapshot event commits the current run payload hash."""
+
+    row = con.execute(
+        """
+        SELECT payload_json FROM ledger_events
+        WHERE run_id = ? AND event_type = 'snapshot_committed'
+        ORDER BY event_id DESC LIMIT 1
+        """,
+        (run_id,),
+    ).fetchone()
+    if row is None:
+        raise EnforcementError(f"SQLite ledger for run {run_id!r} has no snapshot event")
+    event_payload = _json_loads_object(
+        str(row["payload_json"] or "{}"),
+        context="ledger_events.snapshot_committed.payload_json",
+    )
+    expected_payload_sha = str(event_payload.get("payload_sha256") or "")
+    actual_payload_sha = _sha256_text(payload_json)
+    if expected_payload_sha != actual_payload_sha:
+        raise EnforcementError("SQLite ledger head event does not match run payload")
+
+
+def persist_run(run: RunState) -> None:
+    """Persist a run into SQLite source-of-truth plus inspection exports.
+
+    The SQLite write is a single IMMEDIATE transaction.  A tamper-evident
+    snapshot event is appended on every successful commit.  JSON/TSV files are
+    compatibility exports; they are not the source of truth once ``run.sqlite``
+    exists, but export failures still fail closed so users do not rely on stale
+    inspection ledgers.
+    """
+
+    try:
+        payload = run_to_payload(run)
+        db_path = run_sqlite_path(run.run_id)
+        with _connect(db_path) as con:
+            _ensure_schema(con)
+            con.execute("BEGIN IMMEDIATE")
+            _replace_table_rows(con, run, payload)
+            _append_event(
+                con,
+                run_id=run.run_id,
+                event_type="snapshot_committed",
+                object_type="run",
+                object_id=run.run_id,
+                payload=_content_manifest(run),
+            )
+            con.commit()
+        _write_exports(run, payload)
+    except EnforcementError:
+        raise
+    except Exception as exc:
+        raise EnforcementError(
+            f"Failed to persist run ledger: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def verify_event_hash_chain(path: Path, run_id: str) -> Dict[str, Any]:
+    """Verify the per-run event hash chain and payload hashes."""
+
+    if not path.exists():
+        raise FileNotFoundError(path)
+    with _connect(path) as con:
+        _ensure_schema(con)
+        rows = con.execute(
+            """
+            SELECT event_id, run_id, ts, event_type, object_type, object_id,
+                   payload_json, payload_sha256, prev_event_hash, event_hash
+            FROM ledger_events WHERE run_id = ? ORDER BY event_id ASC
+            """,
+            (run_id,),
+        ).fetchall()
+    prev = "GENESIS"
+    for row in rows:
+        payload_sha = _sha256_text(str(row["payload_json"] or ""))
+        if payload_sha != row["payload_sha256"]:
+            raise EnforcementError(f"Ledger event {row['event_id']} payload hash mismatch")
+        if str(row["prev_event_hash"] or "") != prev:
+            raise EnforcementError(f"Ledger event {row['event_id']} previous hash mismatch")
+        expected = _sha256_text(
+            _json_dumps(
+                {
+                    "run_id": row["run_id"],
+                    "ts": float(row["ts"]),
+                    "event_type": row["event_type"],
+                    "object_type": row["object_type"],
+                    "object_id": row["object_id"],
+                    "payload_sha256": row["payload_sha256"],
+                    "prev_event_hash": row["prev_event_hash"],
+                }
+            )
+        )
+        if expected != row["event_hash"]:
+            raise EnforcementError(f"Ledger event {row['event_id']} event hash mismatch")
+        prev = str(row["event_hash"])
+    return {"events": len(rows), "head_event_hash": None if not rows else prev}
+
+
+def _load_from_sqlite(path: Path, run_id: str) -> RunState:
+    with _connect(path) as con:
+        _ensure_schema(con)
+        row = con.execute(
+            "SELECT payload_json, payload_sha256 FROM runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            raise FileNotFoundError(path)
+        payload_json = str(row["payload_json"] or "")
+        if _sha256_text(payload_json) != str(row["payload_sha256"] or ""):
+            raise EnforcementError(f"Run payload hash mismatch in {path}")
+        payload = _json_loads_object(payload_json, context=f"{path}:runs.payload_json")
+        _verify_normalized_tables(con, run_id=run_id, payload=payload)
+        _verify_head_event_matches_payload(con, run_id=run_id, payload_json=payload_json)
+    verify_event_hash_chain(path, run_id)
+    return run_from_payload(payload, fallback_run_id=run_id)
+
+
+def _load_from_json(path: Path, run_id: str) -> RunState:
+    raw = _json_loads_object(path.read_text(encoding="utf-8"), context=str(path))
+    return run_from_payload(raw, fallback_run_id=run_id)
+
+
+def load_persisted_run(run_id: str) -> RunState:
+    rid = str(run_id or "").strip()
+    if not rid:
+        raise EnforcementError("run_id is required")
+    sqlite_path = run_sqlite_path(rid)
+    if sqlite_path.exists():
+        return _load_from_sqlite(sqlite_path, rid)
+    json_path = run_json_path(rid)
+    if json_path.exists():
+        run = _load_from_json(json_path, rid)
+        # JSON-only runs are legacy compatibility input.  Migrate them into
+        # the SQLite ledger immediately so subsequent loads get hash-chain
+        # verification and normalized graph tables.  Fail closed if the
+        # migration cannot be committed.
+        persist_run(run)
+        return run
+    raise FileNotFoundError(run_dir(rid))
+
+
+# ---------------------------------------------------------------------------
+# Inspection exports
+# ---------------------------------------------------------------------------
+
+
+def _write_exports(run: RunState, payload: Dict[str, Any]) -> None:
+    run_json = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    atomic_write_text(run_json_path(run.run_id), run_json)
+    _write_evidence_tsv(run)
+    _write_attempts_tsv(run)
+    _write_claims_tsv(run)
+    _write_claim_evidence_tsv(run)
+    _write_audits_tsv(run)
+    _write_ledger_events_jsonl(run.run_id)
+
+
+def _write_ledger_events_jsonl(run_id: str) -> None:
+    path = ledger_events_jsonl_path(run_id)
+    rows: List[Dict[str, Any]] = []
+    with _connect(run_sqlite_path(run_id)) as con:
+        _ensure_schema(con)
+        for row in con.execute(
+            """
+            SELECT event_id, run_id, ts, event_type, object_type, object_id,
+                   payload_json, payload_sha256, prev_event_hash, event_hash
+            FROM ledger_events WHERE run_id = ? ORDER BY event_id ASC
+            """,
+            (run_id,),
+        ):
+            rows.append(
+                {
+                    "event_id": int(row["event_id"]),
+                    "run_id": row["run_id"],
+                    "ts": float(row["ts"]),
+                    "event_type": row["event_type"],
+                    "object_type": row["object_type"],
+                    "object_id": row["object_id"],
+                    "payload_sha256": row["payload_sha256"],
+                    "prev_event_hash": row["prev_event_hash"],
+                    "event_hash": row["event_hash"],
+                    "payload": _json_loads_object(
+                        row["payload_json"],
+                        context=f"{path}:ledger_events.payload_json",
+                    ),
+                }
+            )
+    atomic_write_text(path, "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows))
+
+
+def _write_evidence_tsv(run: RunState) -> None:
+    path = evidence_tsv_path(run.run_id)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{time.time_ns()}")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            writer.writerow(
+                [
+                    "ts",
+                    "run_id",
+                    "sid",
+                    "eid",
+                    "source",
+                    "source_type",
+                    "kind",
+                    "trust",
+                    "status",
+                    "sensitivity",
+                    "locator",
+                    "parents",
+                    "text_sha256",
+                    "chars",
+                    "preview",
+                ]
+            )
+            for sid in run.span_order:
+                rec = run.spans.get(sid)
+                if not rec:
+                    continue
+                locator = ""
+                if rec.locator:
+                    path_val = rec.locator.get("path") or rec.locator.get("rel_path") or ""
+                    start = rec.locator.get("start_line", "")
+                    end = rec.locator.get("end_line", "")
+                    locator = f"{path_val}:{start}-{end}" if path_val else json.dumps(rec.locator)
+                writer.writerow(
+                    [
+                        f"{float(rec.created_at):.6f}",
+                        run.run_id,
+                        rec.sid,
+                        rec.eid,
+                        rec.source,
+                        rec.source_type,
+                        rec.kind,
+                        rec.trust,
+                        rec.status,
+                        rec.sensitivity,
+                        locator,
+                        ",".join(rec.parents),
+                        rec.text_sha256,
+                        len(rec.text),
+                        rec.preview(limit=200, redact_sensitive=True),
+                    ]
+                )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _write_attempts_tsv(run: RunState) -> None:
+    path = attempts_tsv_path(run.run_id)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{time.time_ns()}")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            writer.writerow(
+                [
+                    "ts",
+                    "run_id",
+                    "attempt_id",
+                    "claim_id",
+                    "hypothesis",
+                    "action",
+                    "budget_minutes",
+                    "input_sids",
+                    "output_sids",
+                    "audit_status",
+                    "decision",
+                    "next_step",
+                ]
+            )
+            for rec in run.attempts:
+                writer.writerow(
+                    [
+                        f"{float(rec.created_at):.6f}",
+                        run.run_id,
+                        rec.attempt_id,
+                        rec.claim_id,
+                        rec.hypothesis,
+                        rec.action,
+                        f"{float(rec.budget_minutes):.2f}",
+                        ",".join(rec.input_sids),
+                        ",".join(rec.output_sids),
+                        rec.audit_status,
+                        rec.decision,
+                        rec.next_step,
+                    ]
+                )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _write_claims_tsv(run: RunState) -> None:
+    path = claims_tsv_path(run.run_id)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{time.time_ns()}")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            writer.writerow(
+                [
+                    "ts",
+                    "run_id",
+                    "cid",
+                    "kind",
+                    "status",
+                    "target",
+                    "latest_audit_id",
+                    "evidence_sids",
+                    "claim",
+                ]
+            )
+            for cid in run.claim_order:
+                rec = run.claims.get(cid)
+                if not rec:
+                    continue
+                evidence = [link.sid for link in run.claim_evidence_links if link.cid == rec.cid]
+                writer.writerow(
+                    [
+                        f"{float(rec.created_at):.6f}",
+                        run.run_id,
+                        rec.cid,
+                        rec.kind,
+                        rec.status,
+                        f"{float(rec.target):.4f}",
+                        rec.latest_audit_id,
+                        ",".join(evidence),
+                        rec.text,
+                    ]
+                )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _write_claim_evidence_tsv(run: RunState) -> None:
+    path = claim_evidence_tsv_path(run.run_id)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{time.time_ns()}")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            writer.writerow(
+                [
+                    "ts",
+                    "run_id",
+                    "link_id",
+                    "cid",
+                    "sid",
+                    "relation",
+                    "audit_id",
+                    "created_by",
+                    "note",
+                ]
+            )
+            for rec in run.claim_evidence_links:
+                writer.writerow(
+                    [
+                        f"{float(rec.created_at):.6f}",
+                        run.run_id,
+                        rec.link_id,
+                        rec.cid,
+                        rec.sid,
+                        rec.relation,
+                        rec.audit_id,
+                        rec.created_by,
+                        rec.note,
+                    ]
+                )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _write_audits_tsv(run: RunState) -> None:
+    path = audits_tsv_path(run.run_id)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{time.time_ns()}")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.writer(fh, delimiter="\t")
+            writer.writerow(
+                [
+                    "ts",
+                    "run_id",
+                    "audit_id",
+                    "kind",
+                    "claim_ids",
+                    "input_sids",
+                    "materialized_sids",
+                    "evidence_pack_id",
+                    "evidence_pack_hash",
+                    "audit_sid",
+                ]
+            )
+            for rec in run.audits:
+                writer.writerow(
+                    [
+                        f"{float(rec.created_at):.6f}",
+                        run.run_id,
+                        rec.audit_id,
+                        rec.kind,
+                        ",".join(rec.claim_ids),
+                        ",".join(rec.input_sids),
+                        ",".join(rec.materialized_sids),
+                        rec.evidence_pack_id,
+                        rec.evidence_pack_hash,
+                        rec.audit_sid,
+                    ]
+                )
+        os.replace(tmp, path)
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass

--- a/tests/e2e/test_cli_install.py
+++ b/tests/e2e/test_cli_install.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _env(tmp_home: Path) -> dict[str, str]:
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    return {
+        **os.environ,
+        "HOME": str(tmp_home),
+        "BERRY_HOME": str(tmp_home / ".berry"),
+        "BERRY_DISABLE_AUTO_AUTH": "1",
+        "PYTHONPATH": str(src_dir) + (os.pathsep + os.environ.get("PYTHONPATH", ""))
+        if os.environ.get("PYTHONPATH")
+        else str(src_dir),
+    }
+
+
+def test_berry_install_codex_cli_refreshes_embedded_command(tmp_repo: Path, tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    env = _env(home)
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "berry",
+            "install",
+            "--platform",
+            "codex",
+            "--berry-command",
+            "/first/berry",
+        ],
+        cwd=tmp_repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "berry",
+            "codex",
+            "install",
+            "--berry-command",
+            "/second/berry",
+        ],
+        cwd=tmp_repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    config = (home / ".codex" / "config.toml").read_text(encoding="utf-8")
+    agents = (home / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+    assert 'command = "/second/berry"' in config
+    assert "/second/berry mcp --server classic" in agents
+    assert "/first/berry" not in config
+    assert "/first/berry" not in agents
+
+
+def test_berry_install_dry_run_json_has_no_side_effects(tmp_repo: Path, tmp_path: Path):
+    home = tmp_path / "home"
+    home.mkdir()
+    env = _env(home)
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "berry",
+            "install",
+            "--platform",
+            "gemini",
+            "--dry-run",
+            "--json",
+            "--berry-command",
+            "/abs/berry",
+        ],
+        cwd=tmp_repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    actions = json.loads(res.stdout)
+    assert actions
+    assert {a["status"] for a in actions} == {"dry-run"}
+    assert not (home / ".gemini").exists()

--- a/tests/e2e/test_mcp_server.py
+++ b/tests/e2e/test_mcp_server.py
@@ -49,6 +49,7 @@ async def test_mcp_server_tools_and_prompts(tmp_repo: Path, tmp_berry_home: Path
             assert "start_run" in tool_names
             assert "load_run" in tool_names
             assert "get_deliverable" in tool_names
+            assert "export_run_ledger" in tool_names
 
             # Evidence span tools
             assert "add_span" in tool_names
@@ -247,7 +248,12 @@ async def test_mcp_server_run_and_spans(tmp_repo: Path, tmp_berry_home: Path):
             assert load_r.isError is False
             assert load_r.structuredContent["result"]["run_id"] == run_id
 
-            # Persistence side-effects should include machine-readable ledgers.
+            # Persistence side-effects should include the authoritative SQLite ledger.
             run_dir = tmp_berry_home / "runs" / run_id
+            assert (run_dir / "run.sqlite").exists()
+
+            # Full inspection exports are explicit so long span sessions stay fast.
+            exp = await session.call_tool("export_run_ledger", {"run_id": run_id})
+            assert exp.isError is False
             assert (run_dir / "evidence.tsv").exists()
             assert (run_dir / "attempts.tsv").exists()

--- a/tests/unit/test_claim_evidence_graph.py
+++ b/tests/unit/test_claim_evidence_graph.py
@@ -88,6 +88,7 @@ def test_claim_steps_use_open_claims_and_linked_supporting_evidence() -> None:
     assert steps[0]["cites"] == []
     assert steps[1]["cites"] == [span.sid]
 
+
 def test_claim_steps_do_not_pack_non_citable_background_anchors() -> None:
     store = RunStore()
     run = store.start_run(run_id="claims")

--- a/tests/unit/test_claim_evidence_graph.py
+++ b/tests/unit/test_claim_evidence_graph.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from berry.enforcement import EnforcementError, RunStore
+from berry.mcp_server import _load_persisted_run, _persist_run
+
+
+def test_claim_graph_create_link_list_update_and_persist(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="claims")
+    span = store.add_span(run=run, text="The implementation added a SQLite ledger.", source="diff")
+    claim = store.create_claim(
+        run=run,
+        text="The implementation added a SQLite ledger.",
+        kind="fact",
+        target=0.95,
+        tags=["storage"],
+    )
+    link = store.link_claim_evidence(run=run, cid=claim.cid, sid=span.sid, relation="supports")
+
+    listed = store.list_claims(run=run)
+    assert listed[0]["cid"] == claim.cid
+    assert listed[0]["evidence"][0]["link_id"] == link.link_id
+
+    audit = store.record_audit(
+        run=run,
+        kind="manual",
+        claim_ids=[claim.cid],
+        input_sids=[span.sid],
+        materialized_sids=[span.sid],
+        evidence_pack_id="pack1",
+        evidence_pack_hash="hash1",
+        verifier_model="scripted",
+        result={"status": "passed"},
+    )
+    updated = store.update_claim(
+        run=run,
+        cid=claim.cid,
+        status="supported",
+        target=0.9,
+        tags_add=["audited"],
+        latest_audit_id=audit.audit_id,
+    )
+    assert updated.status == "supported"
+    assert updated.target == 0.9
+    assert "audited" in updated.tags
+    assert updated.latest_audit_id == audit.audit_id
+
+    _persist_run(run)
+    loaded = _load_persisted_run("claims")
+    assert loaded.claims[claim.cid].status == "supported"
+    assert loaded.claim_evidence_links[0].relation == "supports"
+    assert loaded.audits[0].claim_ids == [claim.cid]
+
+
+def test_claim_graph_rejects_unknown_or_non_citable_support_edges() -> None:
+    store = RunStore()
+    run = store.start_run(run_id="claims")
+    claim = store.create_claim(run=run, text="The task was completed.")
+    anchor = store.add_span(run=run, text="Please complete the task.", source="anchor")
+
+    with pytest.raises(EnforcementError, match="Unknown span id"):
+        store.link_claim_evidence(run=run, cid=claim.cid, sid="S999", relation="supports")
+
+    with pytest.raises(EnforcementError, match="not citable"):
+        store.link_claim_evidence(run=run, cid=claim.cid, sid=anchor.sid, relation="supports")
+
+    background = store.link_claim_evidence(
+        run=run, cid=claim.cid, sid=anchor.sid, relation="background"
+    )
+    assert background.relation == "background"
+
+
+def test_claim_steps_use_open_claims_and_linked_supporting_evidence() -> None:
+    store = RunStore()
+    run = store.start_run(run_id="claims")
+    span = store.add_span(run=run, text="Benchmark latency is 42 ms.", source="benchmark")
+    unsupported = store.create_claim(run=run, text="This claim has no evidence.")
+    supported = store.create_claim(run=run, text="Benchmark latency is 42 ms.")
+    store.link_claim_evidence(run=run, cid=supported.cid, sid=span.sid, relation="supports")
+
+    steps = store.claim_steps(run=run, claim_ids=[unsupported.cid, supported.cid])
+
+    assert [step["claim_id"] for step in steps] == [unsupported.cid, supported.cid]
+    assert steps[0]["cites"] == []
+    assert steps[1]["cites"] == [span.sid]
+
+def test_claim_steps_do_not_pack_non_citable_background_anchors() -> None:
+    store = RunStore()
+    run = store.start_run(run_id="claims")
+    claim = store.create_claim(run=run, text="The migration was implemented.")
+    anchor = store.add_span(run=run, text="Please implement the migration.", source="anchor")
+    evidence = store.add_span(
+        run=run,
+        text="run.sqlite is written during persist_run.",
+        source="diff",
+    )
+
+    store.link_claim_evidence(run=run, cid=claim.cid, sid=anchor.sid, relation="background")
+    store.link_claim_evidence(run=run, cid=claim.cid, sid=evidence.sid, relation="supports")
+
+    steps = store.claim_steps(
+        run=run,
+        claim_ids=[claim.cid],
+        evidence_relations=["supports", "background"],
+    )
+
+    assert steps == [
+        {
+            "idx": 0,
+            "claim_id": claim.cid,
+            "claim": claim.text,
+            "cites": [evidence.sid],
+            "confidence": claim.target,
+        }
+    ]

--- a/tests/unit/test_installer.py
+++ b/tests/unit/test_installer.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from berry.installer import actions_to_json, install_many, platform_keys
+
+EXPECTED_PLATFORMS = {
+    "claude",
+    "windows",
+    "codebuddy",
+    "codex",
+    "opencode",
+    "kilo",
+    "copilot",
+    "vscode",
+    "aider",
+    "claw",
+    "droid",
+    "trae",
+    "trae-cn",
+    "gemini",
+    "hermes",
+    "kimi",
+    "amp",
+    "kiro",
+    "pi",
+    "cursor",
+    "devin",
+    "antigravity",
+}
+
+
+def test_platform_registry_surface() -> None:
+    assert EXPECTED_PLATFORMS.issubset(set(platform_keys()))
+
+
+def test_codex_install_embeds_and_refreshes_command_preserving_user_toml(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    codex_config = tmp_path / ".codex" / "config.toml"
+    codex_config.parent.mkdir(parents=True)
+    codex_config.write_text(
+        '[features]\nfoo = true\nmulti_agent = false\n\n[user]\nname = "me"\n',
+        encoding="utf-8",
+    )
+
+    actions = install_many(
+        ["codex"],
+        scope="user",
+        project_dir=None,
+        force=False,
+        dry_run=False,
+        berry_command_raw="/opt/berry/bin/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=True,
+    )
+
+    assert all(a.status != "failed" for a in actions)
+    assert (tmp_path / ".codex" / "skills" / "berry" / "SKILL.md").exists()
+    agents = (tmp_path / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+    assert "/opt/berry/bin/berry mcp --server classic" in agents
+    config = codex_config.read_text(encoding="utf-8")
+    assert "[features]" in config
+    assert "foo = true" in config
+    assert "multi_agent = true" in config
+    assert "[user]" in config
+    assert 'command = "/opt/berry/bin/berry"' in config
+
+    install_many(
+        ["codex"],
+        scope="user",
+        project_dir=None,
+        force=False,
+        dry_run=False,
+        berry_command_raw="/new/location/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=True,
+    )
+    refreshed = codex_config.read_text(encoding="utf-8")
+    refreshed_agents = (tmp_path / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+    assert 'command = "/new/location/berry"' in refreshed
+    assert "/opt/berry/bin/berry" not in refreshed
+    assert "/new/location/berry mcp --server classic" in refreshed_agents
+    assert "/opt/berry/bin/berry" not in refreshed_agents
+
+
+def test_claude_project_install_upserts_hooks_and_mcp_without_destroying_existing_json(
+    tmp_repo: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_repo)
+    settings = tmp_repo / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        json.dumps({"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": []}]}, "x": 1}),
+        encoding="utf-8",
+    )
+
+    actions = install_many(
+        ["claude"],
+        scope="project",
+        project_dir=tmp_repo,
+        force=False,
+        dry_run=False,
+        berry_command_raw="/abs/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=True,
+    )
+
+    assert all(a.status != "failed" for a in actions)
+    assert (tmp_repo / ".claude" / "skills" / "berry" / "SKILL.md").exists()
+    assert (tmp_repo / ".claude" / "CLAUDE.md").exists()
+    payload = json.loads(settings.read_text(encoding="utf-8"))
+    assert payload["x"] == 1
+    pre = payload["hooks"]["PreToolUse"]
+    assert len(pre) == 3  # original + Berry Bash + Berry Read|Glob
+    assert any("/abs/berry mcp --server classic" in json.dumps(h) for h in pre)
+    mcp = json.loads((tmp_repo / ".mcp.json").read_text(encoding="utf-8"))
+    assert mcp["mcpServers"]["berry"]["command"] == "/abs/berry"
+
+
+def test_invalid_json_fails_closed_unless_force(tmp_repo: Path) -> None:
+    settings = tmp_repo / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text("{ definitely not json", encoding="utf-8")
+
+    actions = install_many(
+        ["claude"],
+        scope="project",
+        project_dir=tmp_repo,
+        force=False,
+        dry_run=False,
+        berry_command_raw="/abs/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=False,
+    )
+    failed = [a for a in actions if a.kind == "hooks"]
+    assert failed and failed[0].status == "failed"
+    assert settings.read_text(encoding="utf-8") == "{ definitely not json"
+
+    repaired = install_many(
+        ["claude"],
+        scope="project",
+        project_dir=tmp_repo,
+        force=True,
+        dry_run=False,
+        berry_command_raw="/abs/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=False,
+    )
+    assert all(a.status != "failed" for a in repaired)
+    assert json.loads(settings.read_text(encoding="utf-8"))["hooks"]["PreToolUse"]
+
+
+def test_malformed_managed_markdown_section_fails_closed(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agents = tmp_path / ".codex" / "AGENTS.md"
+    agents.parent.mkdir(parents=True)
+    agents.write_text("human text\n<!-- berry:install:start -->\npartial\n", encoding="utf-8")
+
+    actions = install_many(
+        ["codex"],
+        scope="user",
+        project_dir=None,
+        force=False,
+        dry_run=False,
+        berry_command_raw="/abs/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=False,
+    )
+
+    failed = [a for a in actions if a.kind == "instructions"]
+    assert failed and failed[0].status == "failed"
+    assert (
+        agents.read_text(encoding="utf-8") == "human text\n<!-- berry:install:start -->\npartial\n"
+    )
+
+
+def test_dry_run_does_not_write(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    actions = install_many(
+        ["gemini"],
+        scope="user",
+        project_dir=None,
+        force=False,
+        dry_run=True,
+        berry_command_raw="/abs/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=True,
+    )
+    assert actions
+    assert {a.status for a in actions} == {"dry-run"}
+    assert not (tmp_path / ".gemini").exists()
+    # JSON serialization is part of the public CLI contract.
+    parsed = json.loads(actions_to_json(actions))
+    assert parsed[0]["platform"] == "gemini"
+
+
+def test_cursor_user_install_writes_project_rule_but_user_mcp(tmp_path: Path, monkeypatch) -> None:
+    home = tmp_path / "home"
+    repo = tmp_path / "repo"
+    home.mkdir()
+    repo.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    actions = install_many(
+        ["cursor"],
+        scope="user",
+        project_dir=repo,
+        force=False,
+        dry_run=False,
+        berry_command_raw="/abs/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=True,
+    )
+    assert all(a.status != "failed" for a in actions)
+    assert (repo / ".cursor" / "rules" / "berry.mdc").exists()
+    mcp = json.loads((home / ".cursor" / "mcp.json").read_text(encoding="utf-8"))
+    assert mcp["mcpServers"]["berry"]["command"] == "/abs/berry"
+
+
+def test_vscode_project_install_uses_vscode_mcp_shape(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    actions = install_many(
+        ["vscode"],
+        scope="project",
+        project_dir=repo,
+        force=False,
+        dry_run=False,
+        berry_command_raw="/abs/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=True,
+    )
+    assert all(a.status != "failed" for a in actions)
+    assert (repo / ".github" / "copilot-instructions.md").exists()
+    mcp = json.loads((repo / ".vscode" / "mcp.json").read_text(encoding="utf-8"))
+    assert "servers" in mcp
+    assert mcp["servers"]["berry"]["command"] == "/abs/berry"
+    assert "mcpServers" not in mcp
+
+
+def test_kilo_project_install_writes_and_registers_plugin(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".kilo").mkdir()
+    (repo / ".kilo" / "kilo.jsonc").write_text(
+        '{\n  // user plugin\n  "plugin": ["file:///existing.js"],\n}\n',
+        encoding="utf-8",
+    )
+
+    actions = install_many(
+        ["kilo"],
+        scope="project",
+        project_dir=repo,
+        force=False,
+        dry_run=False,
+        berry_command_raw="/abs/berry",
+        name="berry",
+        install_hooks=True,
+        install_mcp=True,
+    )
+
+    assert all(a.status != "failed" for a in actions)
+    assert (repo / ".kilo" / "plugins" / "berry.js").exists()
+    config = json.loads((repo / ".kilo" / "kilo.json").read_text(encoding="utf-8"))
+    assert "file:///existing.js" in config["plugin"]
+    assert (repo / ".kilo" / "plugins" / "berry.js").resolve().as_uri() in config["plugin"]

--- a/tests/unit/test_integration.py
+++ b/tests/unit/test_integration.py
@@ -119,3 +119,31 @@ def test_upsert_codex_toml_overwrites_env_block(tmp_path: Path):
     assert updated.count("[mcp_servers.berry.env]") == 1
     assert '"OPENAI_API_KEY" = "new"' in updated
     assert '"OPENAI_API_KEY" = "old"' not in updated
+
+
+def test_upsert_codex_toml_preserves_unrelated_sections(tmp_path: Path):
+    codex_toml = tmp_path / ".codex" / "config.toml"
+    codex_toml.parent.mkdir(parents=True, exist_ok=True)
+    codex_toml.write_text(
+        (
+            "[mcp_servers.berry]\n"
+            'command = "old"\n'
+            'args = ["mcp"]\n'
+            "\n"
+            "[features]\n"
+            "multi_agent = false\n"
+            "experimental = true\n"
+            "\n"
+            "[user]\n"
+            'name = "me"\n'
+        ),
+        encoding="utf-8",
+    )
+    spec = McpServerSpec(name="berry", command="/abs/berry", args=["mcp"], env={})
+    _upsert_codex_toml(codex_toml, spec)
+    updated = codex_toml.read_text(encoding="utf-8")
+    assert "[features]" in updated
+    assert "experimental = true" in updated
+    assert "[user]" in updated
+    assert 'name = "me"' in updated
+    assert 'command = "/abs/berry"' in updated

--- a/tests/unit/test_span_management_v2.py
+++ b/tests/unit/test_span_management_v2.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from berry.enforcement import EnforcementError, RunStore, SpanRecord
+from berry.mcp_server import _load_persisted_run, _persist_run, _run_json_path, _run_sqlite_path
+from berry.run_ledger import load_persisted_run, verify_event_hash_chain
+
+
+def test_span_record_v2_classifies_anchor_and_redacts_secrets() -> None:
+    store = RunStore()
+    run = store.start_run(run_id="r")
+
+    anchor = store.add_span(
+        run=run,
+        text="Build a verifier.",
+        source="anchor",
+        meta={"kind": "problem"},
+    )
+    secret = store.add_span(
+        run=run,
+        text="OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz1234567890",
+        source="manual",
+    )
+
+    assert anchor.kind == "anchor"
+    assert anchor.is_citable is False
+    assert secret.sensitivity == "secret"
+    assert secret.is_sensitive is True
+
+    listed = store.list_spans(run=run)
+    by_sid = {s["sid"]: s for s in listed}
+    assert by_sid[anchor.sid]["kind"] == "anchor"
+    assert by_sid[secret.sid]["preview"] == "[REDACTED sensitive span]"
+    assert by_sid[secret.sid]["text_sha256"] == secret.text_sha256
+
+
+def test_resolve_evidence_pack_excludes_non_citable_unsafe_and_unknown_spans() -> None:
+    store = RunStore()
+    run = store.start_run(run_id="r")
+    anchor = store.add_span(run=run, text="Desired outcome", source="anchor")
+    evidence = store.add_span(run=run, text="The test passed with exit code 0.", source="test")
+    secret = store.add_span(run=run, text="password=supersecret123", source="log")
+    stale = store.add_span(run=run, text="Old result", source="test")
+    store.mark_span(run=run, sid=stale.sid, status="stale")
+    tombstoned = store.add_span(run=run, text="Deleted result", source="test")
+    store.mark_span(run=run, sid=tombstoned.sid, status="tombstoned")
+
+    pack = store.resolve_evidence_pack(
+        run=run,
+        sids=[anchor.sid, evidence.sid, secret.sid, stale.sid, tombstoned.sid, "S999"],
+    )
+
+    assert pack["materialized_sids"] == [evidence.sid]
+    reasons = {(e["sid"], e["reason"]) for e in pack["excluded"]}
+    assert (anchor.sid, "kind:anchor") in reasons
+    assert (secret.sid, "sensitivity:secret") in reasons
+    assert (stale.sid, "status:stale") in reasons
+    assert (tombstoned.sid, "status:tombstoned") in reasons
+    assert ("S999", "unknown") in reasons
+
+    stale_allowed = store.resolve_evidence_pack(run=run, sids=[stale.sid], include_stale=True)
+    assert stale_allowed["materialized_sids"] == [stale.sid]
+    tombstone_allowed = store.resolve_evidence_pack(
+        run=run, sids=[tombstoned.sid], include_stale=True
+    )
+    assert tombstone_allowed["materialized_sids"] == []
+    assert tombstone_allowed["excluded"] == [
+        {"sid": tombstoned.sid, "reason": "status:tombstoned"}
+    ]
+    assert pack["pack_id"]
+    assert pack["text_sha256"]
+
+
+def test_extract_span_no_match_does_not_create_citable_placeholder() -> None:
+    store = RunStore()
+    run = store.start_run(run_id="r")
+    parent = store.add_span(
+        run=run,
+        text="alpha\nbeta\ngamma",
+        source="file",
+        source_type="file",
+        locator={"path": "x.py", "start_line": 1, "end_line": 3},
+    )
+    before = list(run.span_order)
+
+    no_match = store.extract_span(
+        run=run,
+        parent_sid=parent.sid,
+        selector={"type": "regex", "pattern": "delta"},
+    )
+
+    assert no_match["matched"] is False
+    assert no_match["sid"] is None
+    assert run.span_order == before
+
+    match = store.extract_span(
+        run=run,
+        parent_sid=parent.sid,
+        selector={"type": "regex", "pattern": "beta"},
+        reason="narrow to relevant assertion",
+    )
+
+    assert match["matched"] is True
+    child = store.get_span(run=run, sid=match["sid"])
+    assert child.text == "beta"
+    assert child.kind == "derived"
+    assert child.parents == [parent.sid]
+    assert child.transform and child.transform["type"] == "regex_extract"
+    assert child.is_citable is True
+
+
+def test_resolve_evidence_pack_surfaces_parents_for_non_extract_derived_summary() -> None:
+    store = RunStore()
+    run = store.start_run(run_id="r")
+    parent = store.add_span(run=run, text="Primary source says the value is 42.", source="source")
+    summary = store.add_span(
+        run=run,
+        text="The value is 42.",
+        source="summary",
+        source_type="summary",
+        kind="derived",
+        parents=[parent.sid],
+        transform={"type": "summary"},
+        trust="derived",
+    )
+
+    pack = store.resolve_evidence_pack(run=run, sids=[summary.sid])
+
+    assert pack["materialized_sids"] == [parent.sid]
+    assert any(
+        e["sid"] == summary.sid and e["reason"] == "derived_not_extractively_citable"
+        for e in pack["excluded"]
+    )
+
+
+def test_query_evidence_filters_kind_source_status_and_excludes_derived_by_default() -> None:
+    store = RunStore()
+    run = store.start_run(run_id="r")
+    file_span = store.add_span(
+        run=run,
+        text="Graph extraction completed successfully.",
+        source="file",
+        source_type="file",
+        kind="evidence",
+    )
+    store.add_span(
+        run=run,
+        text="Graph extraction summary.",
+        source="summary",
+        source_type="summary",
+        kind="derived",
+        parents=[file_span.sid],
+        transform={"type": "summary"},
+    )
+
+    default_results = store.query_evidence(run=run, query="graph extraction")
+    assert [r["sid"] for r in default_results] == [file_span.sid]
+
+    file_results = store.query_evidence(
+        run=run,
+        query="graph extraction",
+        source_types=["file"],
+    )
+    assert [r["sid"] for r in file_results] == [file_span.sid]
+
+    with_derived = store.query_evidence(
+        run=run,
+        query="graph extraction",
+        include_derived=True,
+    )
+    assert len(with_derived) == 2
+
+
+def test_persisted_run_round_trips_v2_span_fields(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="roundtrip")
+    run.baseline_kind = "git"
+    run.baseline_ref = "abc123"
+    parent = store.add_span(
+        run=run,
+        text="line 1\nline 2",
+        source="file",
+        source_type="file",
+        kind="evidence",
+        locator={"path": "src/x.py", "start_line": 1, "end_line": 2},
+        snapshot={"file_sha256": "filehash"},
+        tags=["file"],
+    )
+    child = store.extract_span(
+        run=run,
+        parent_sid=parent.sid,
+        selector={"type": "line_range", "start_line": 2, "end_line": 2},
+    )["sid"]
+
+    _persist_run(run)
+    loaded = _load_persisted_run("roundtrip")
+
+    assert loaded.baseline_kind == "git"
+    assert loaded.baseline_ref == "abc123"
+    assert loaded.spans[parent.sid].locator["path"] == "src/x.py"
+    assert loaded.spans[parent.sid].snapshot["file_sha256"] == "filehash"
+    assert loaded.spans[child].parents == [parent.sid]
+    assert loaded.spans[child].kind == "derived"
+
+    payload = json.loads((tmp_berry_home / "runs" / "roundtrip" / "run.json").read_text())
+    assert payload["schema_version"] == 3
+    assert payload["spans"][parent.sid]["text_sha256"] == parent.text_sha256
+    assert _run_sqlite_path("roundtrip").exists()
+    assert verify_event_hash_chain(_run_sqlite_path("roundtrip"), "roundtrip")["events"] == 1
+    assert (tmp_berry_home / "runs" / "roundtrip" / "ledger_events.jsonl").exists()
+
+
+def test_persist_run_fails_closed_on_write_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="fail")
+    store.add_span(run=run, text="evidence", source="manual")
+
+    def boom(path, text):  # type: ignore[no-untyped-def]
+        raise OSError("disk full")
+
+    monkeypatch.setattr("berry.run_ledger.atomic_write_text", boom)
+    with pytest.raises(EnforcementError, match="Failed to persist run ledger"):
+        _persist_run(run)
+
+
+def test_v1_span_record_construction_still_gets_v2_defaults() -> None:
+    rec = SpanRecord(
+        sid="S0",
+        text="hello",
+        source="manual",
+        created_at=1.0,
+        meta={},
+    )
+
+    assert rec.kind == "evidence"
+    assert rec.source_type == "manual"
+    assert rec.status == "active"
+    assert rec.text_sha256
+    assert rec.eid
+
+
+def test_sqlite_ledger_is_source_of_truth_when_json_export_is_missing(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="sqlite-source")
+    span = store.add_span(run=run, text="Measured accuracy is 0.91.", source="metric")
+    claim = store.create_claim(run=run, text="Accuracy is 0.91.", target=0.95)
+    store.link_claim_evidence(run=run, cid=claim.cid, sid=span.sid, relation="supports")
+    store.record_audit(
+        run=run,
+        kind="manual",
+        claim_ids=[claim.cid],
+        input_sids=[span.sid],
+        materialized_sids=[span.sid],
+        evidence_pack_id="pack",
+        evidence_pack_hash="hash",
+        result={"status": "passed"},
+    )
+
+    _persist_run(run)
+    sqlite_path = _run_sqlite_path("sqlite-source")
+    assert sqlite_path.exists()
+    with sqlite3.connect(sqlite_path) as con:
+        assert con.execute("SELECT COUNT(*) FROM spans").fetchone()[0] == 1
+        assert con.execute("SELECT COUNT(*) FROM claims").fetchone()[0] == 1
+        assert con.execute("SELECT COUNT(*) FROM claim_evidence_links").fetchone()[0] == 1
+        assert con.execute("SELECT COUNT(*) FROM audits").fetchone()[0] == 1
+
+    _run_json_path("sqlite-source").unlink()
+    loaded = load_persisted_run("sqlite-source")
+    assert loaded.spans[span.sid].text == span.text
+    assert loaded.claims[claim.cid].text == claim.text
+    assert loaded.claim_evidence_links[0].sid == span.sid
+    assert loaded.audits[0].evidence_pack_id == "pack"
+
+
+def test_sqlite_event_log_tampering_fails_closed(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="tamper")
+    store.add_span(run=run, text="durable fact", source="manual")
+    _persist_run(run)
+
+    sqlite_path = _run_sqlite_path("tamper")
+    with sqlite3.connect(sqlite_path) as con:
+        con.execute(
+            "UPDATE ledger_events SET payload_json = ? WHERE event_id = 1",
+            ('{"tampered":true}',),
+        )
+        con.commit()
+
+    with pytest.raises(EnforcementError, match="payload hash mismatch|head event"):
+        _load_persisted_run("tamper")
+
+
+def test_legacy_json_without_sqlite_still_loads_and_migrates(tmp_berry_home: Path) -> None:
+    run_dir = tmp_berry_home / "runs" / "legacy"
+    run_dir.mkdir(parents=True)
+    payload = {
+        "schema_version": 2,
+        "run_id": "legacy",
+        "created_at": 1.0,
+        "next_span_idx": 1,
+        "span_order": ["S0"],
+        "spans": {
+            "S0": {
+                "sid": "S0",
+                "text": "Legacy evidence.",
+                "source": "manual",
+                "created_at": 1.0,
+            }
+        },
+        "attempts": [],
+    }
+    (run_dir / "run.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = _load_persisted_run("legacy")
+    assert loaded.spans["S0"].kind == "evidence"
+    assert loaded.claims == {}
+    assert loaded.next_claim_idx == 0
+    assert _run_sqlite_path("legacy").exists()
+
+
+def test_sqlite_normalized_table_tampering_fails_closed(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="table-tamper")
+    span = store.add_span(run=run, text="original evidence", source="manual")
+    _persist_run(run)
+
+    sqlite_path = _run_sqlite_path("table-tamper")
+    with sqlite3.connect(sqlite_path) as con:
+        con.execute(
+            "UPDATE spans SET payload_json = ? WHERE run_id = ? AND sid = ?",
+            (json.dumps({"sid": span.sid, "text": "tampered"}), "table-tamper", span.sid),
+        )
+        con.commit()
+
+    with pytest.raises(EnforcementError, match="span table is inconsistent"):
+        _load_persisted_run("table-tamper")
+
+
+def test_sqlite_head_event_must_commit_current_run_payload(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="head-tamper")
+    store.add_span(run=run, text="unchanged evidence", source="manual")
+    _persist_run(run)
+
+    sqlite_path = _run_sqlite_path("head-tamper")
+    with sqlite3.connect(sqlite_path) as con:
+        payload_json = con.execute(
+            "SELECT payload_json FROM runs WHERE run_id = ?", ("head-tamper",)
+        ).fetchone()[0]
+        payload = json.loads(payload_json)
+        payload["baseline_ref"] = "tampered-but-child-tables-still-match"
+        mutated = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            default=str,
+        )
+        con.execute(
+            "UPDATE runs SET payload_json = ?, payload_sha256 = ? WHERE run_id = ?",
+            (mutated, hashlib.sha256(mutated.encode("utf-8")).hexdigest(), "head-tamper"),
+        )
+        con.commit()
+
+    with pytest.raises(EnforcementError, match="head event does not match"):
+        _load_persisted_run("head-tamper")

--- a/tests/unit/test_span_management_v2.py
+++ b/tests/unit/test_span_management_v2.py
@@ -9,7 +9,7 @@ import pytest
 
 from berry.enforcement import EnforcementError, RunStore, SpanRecord
 from berry.mcp_server import _load_persisted_run, _persist_run, _run_json_path, _run_sqlite_path
-from berry.run_ledger import load_persisted_run, verify_event_hash_chain
+from berry.run_ledger import export_run, load_persisted_run, persist_run, verify_event_hash_chain
 
 
 def test_span_record_v2_classifies_anchor_and_redacts_secrets() -> None:
@@ -206,12 +206,43 @@ def test_persisted_run_round_trips_v2_span_fields(tmp_berry_home: Path) -> None:
     assert loaded.spans[child].parents == [parent.sid]
     assert loaded.spans[child].kind == "derived"
 
-    payload = json.loads((tmp_berry_home / "runs" / "roundtrip" / "run.json").read_text())
-    assert payload["schema_version"] == 3
-    assert payload["spans"][parent.sid]["text_sha256"] == parent.text_sha256
     assert _run_sqlite_path("roundtrip").exists()
-    assert verify_event_hash_chain(_run_sqlite_path("roundtrip"), "roundtrip")["events"] == 1
-    assert (tmp_berry_home / "runs" / "roundtrip" / "ledger_events.jsonl").exists()
+    with sqlite3.connect(_run_sqlite_path("roundtrip")) as con:
+        run_payload = json.loads(
+            con.execute(
+                "SELECT payload_json FROM runs WHERE run_id = ?", ("roundtrip",)
+            ).fetchone()[0]
+        )
+        row = con.execute(
+            "SELECT payload_json, payload_sha256 FROM spans WHERE run_id = ? AND sid = ?",
+            ("roundtrip", parent.sid),
+        ).fetchone()
+    assert run_payload["schema_version"] == 4
+    assert run_payload["payload_kind"] == "ledger_head"
+    assert run_payload["counts"]["spans"] == 2
+    assert "spans" not in run_payload
+    span_payload = json.loads(row[0])
+    assert hashlib.sha256(row[0].encode("utf-8")).hexdigest() == row[1]
+    assert span_payload["text_sha256"] == parent.text_sha256
+    chain = verify_event_hash_chain(_run_sqlite_path("roundtrip"), "roundtrip")
+    assert chain["events"] == 1
+    assert chain["saw_incremental"] is True
+
+
+def test_default_persist_keeps_exports_off_until_explicit_export(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="export-off")
+    span = store.add_span(run=run, text="Measured latency is 42 ms.", source="metric")
+    _persist_run(run)
+
+    assert _run_sqlite_path("export-off").exists()
+    assert not _run_json_path("export-off").exists()
+
+    exported = export_run("export-off")
+    assert Path(exported["run_json"]).exists()
+    payload = json.loads(Path(exported["run_json"]).read_text(encoding="utf-8"))
+    assert payload["payload_kind"] == "full_export"
+    assert payload["spans"][span.sid]["text"] == span.text
 
 
 def test_persist_run_fails_closed_on_write_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -219,10 +250,10 @@ def test_persist_run_fails_closed_on_write_failure(monkeypatch: pytest.MonkeyPat
     run = store.start_run(run_id="fail")
     store.add_span(run=run, text="evidence", source="manual")
 
-    def boom(path, text):  # type: ignore[no-untyped-def]
+    def boom(con, run):  # type: ignore[no-untyped-def]
         raise OSError("disk full")
 
-    monkeypatch.setattr("berry.run_ledger.atomic_write_text", boom)
+    monkeypatch.setattr("berry.run_ledger._commit_incremental", boom)
     with pytest.raises(EnforcementError, match="Failed to persist run ledger"):
         _persist_run(run)
 
@@ -269,7 +300,7 @@ def test_sqlite_ledger_is_source_of_truth_when_json_export_is_missing(tmp_berry_
         assert con.execute("SELECT COUNT(*) FROM claim_evidence_links").fetchone()[0] == 1
         assert con.execute("SELECT COUNT(*) FROM audits").fetchone()[0] == 1
 
-    _run_json_path("sqlite-source").unlink()
+    _run_json_path("sqlite-source").unlink(missing_ok=True)
     loaded = load_persisted_run("sqlite-source")
     assert loaded.spans[span.sid].text == span.text
     assert loaded.claims[claim.cid].text == claim.text
@@ -337,7 +368,9 @@ def test_sqlite_normalized_table_tampering_fails_closed(tmp_berry_home: Path) ->
         )
         con.commit()
 
-    with pytest.raises(EnforcementError, match="span table is inconsistent"):
+    with pytest.raises(
+        EnforcementError, match="span table payload hash mismatch|span table is inconsistent"
+    ):
         _load_persisted_run("table-tamper")
 
 
@@ -367,5 +400,152 @@ def test_sqlite_head_event_must_commit_current_run_payload(tmp_berry_home: Path)
         )
         con.commit()
 
-    with pytest.raises(EnforcementError, match="head event does not match"):
+    with pytest.raises(
+        EnforcementError,
+        match="head event does not match|head event hash mismatch|Run payload hash mismatch",
+    ):
         _load_persisted_run("head-tamper")
+
+
+def test_incremental_ledger_appends_one_row_event_per_hot_span_commit(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="incremental")
+
+    for i in range(12):
+        store.add_span(run=run, text=f"Fact {i}.", source="manual")
+        _persist_run(run)
+
+    sqlite_path = _run_sqlite_path("incremental")
+    with sqlite3.connect(sqlite_path) as con:
+        run_payload = json.loads(
+            con.execute(
+                "SELECT payload_json FROM runs WHERE run_id = ?", ("incremental",)
+            ).fetchone()[0]
+        )
+        event_payloads = [
+            json.loads(row[0])
+            for row in con.execute(
+                "SELECT payload_json FROM ledger_events WHERE run_id = ? ORDER BY event_id",
+                ("incremental",),
+            ).fetchall()
+        ]
+
+    assert run_payload["payload_kind"] == "ledger_head"
+    assert "spans" not in run_payload
+    assert len(event_payloads) == 12
+    assert event_payloads[0]["full_snapshot"] is True
+    assert all(payload["format"] == "incremental_v1" for payload in event_payloads)
+    assert all(len(payload["changes"]) == 1 for payload in event_payloads)
+    assert [payload["changes"][0]["id"] for payload in event_payloads] == [
+        f"S{i}" for i in range(12)
+    ]
+    assert verify_event_hash_chain(sqlite_path, "incremental")["events"] == 12
+
+
+def test_sqlite_row_hash_tampering_even_when_row_hash_is_recomputed_fails_closed(
+    tmp_berry_home: Path,
+) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="row-hash-tamper")
+    span = store.add_span(run=run, text="original evidence", source="manual")
+    _persist_run(run)
+
+    sqlite_path = _run_sqlite_path("row-hash-tamper")
+    with sqlite3.connect(sqlite_path) as con:
+        payload_json = con.execute(
+            "SELECT payload_json FROM spans WHERE run_id = ? AND sid = ?",
+            ("row-hash-tamper", span.sid),
+        ).fetchone()[0]
+        payload = json.loads(payload_json)
+        payload["text"] = "tampered but row hash was recomputed"
+        mutated = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        con.execute(
+            "UPDATE spans SET payload_json = ?, payload_sha256 = ? WHERE run_id = ? AND sid = ?",
+            (
+                mutated,
+                hashlib.sha256(mutated.encode("utf-8")).hexdigest(),
+                "row-hash-tamper",
+                span.sid,
+            ),
+        )
+        con.commit()
+
+    with pytest.raises(EnforcementError, match="span table is inconsistent with ledger event log"):
+        _load_persisted_run("row-hash-tamper")
+
+
+def test_clean_persist_does_not_heal_external_ledger_tampering(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="no-heal")
+    span = store.add_span(run=run, text="original evidence", source="manual")
+    _persist_run(run)
+
+    sqlite_path = _run_sqlite_path("no-heal")
+    with sqlite3.connect(sqlite_path) as con:
+        payload_json = con.execute(
+            "SELECT payload_json FROM spans WHERE run_id = ? AND sid = ?",
+            ("no-heal", span.sid),
+        ).fetchone()[0]
+        payload = json.loads(payload_json)
+        payload["text"] = "tampered durable row"
+        mutated = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        con.execute(
+            "UPDATE spans SET payload_json = ?, payload_sha256 = ? WHERE run_id = ? AND sid = ?",
+            (
+                mutated,
+                hashlib.sha256(mutated.encode("utf-8")).hexdigest(),
+                "no-heal",
+                span.sid,
+            ),
+        )
+        con.commit()
+
+    with pytest.raises(EnforcementError, match="span table is inconsistent with ledger event log"):
+        persist_run(run)
+
+
+def test_explicit_export_run_regenerates_full_json_and_tsv_snapshots(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="exportable")
+    span = store.add_span(run=run, text="exported evidence", source="manual")
+    _persist_run(run)
+
+    assert not _run_json_path("exportable").exists()
+    result = export_run("exportable")
+
+    assert result["mode"] == "sync"
+    payload = json.loads(_run_json_path("exportable").read_text())
+    assert payload["payload_kind"] == "full_export"
+    assert payload["spans"][span.sid]["text"] == "exported evidence"
+    assert (tmp_berry_home / "runs" / "exportable" / "evidence.tsv").exists()
+
+
+def test_dirty_write_fails_if_target_row_was_tampered_since_load(tmp_berry_home: Path) -> None:
+    store = RunStore()
+    run = store.start_run(run_id="dirty-row-tamper")
+    span = store.add_span(run=run, text="original evidence", source="manual")
+    _persist_run(run)
+
+    sqlite_path = _run_sqlite_path("dirty-row-tamper")
+    with sqlite3.connect(sqlite_path) as con:
+        payload_json = con.execute(
+            "SELECT payload_json FROM spans WHERE run_id = ? AND sid = ?",
+            ("dirty-row-tamper", span.sid),
+        ).fetchone()[0]
+        payload = json.loads(payload_json)
+        payload["text"] = "tampered durable row"
+        mutated = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+        con.execute(
+            "UPDATE spans SET payload_json = ?, payload_sha256 = ? WHERE run_id = ? AND sid = ?",
+            (
+                mutated,
+                hashlib.sha256(mutated.encode("utf-8")).hexdigest(),
+                "dirty-row-tamper",
+                span.sid,
+            ),
+        )
+        con.commit()
+
+    store.mark_span(run=run, sid=span.sid, tags_add=["reviewed"])
+    with pytest.raises(EnforcementError, match="changed since this run was loaded"):
+        persist_run(run)

--- a/tests/unit/test_span_management_v2.py
+++ b/tests/unit/test_span_management_v2.py
@@ -70,9 +70,7 @@ def test_resolve_evidence_pack_excludes_non_citable_unsafe_and_unknown_spans() -
         run=run, sids=[tombstoned.sid], include_stale=True
     )
     assert tombstone_allowed["materialized_sids"] == []
-    assert tombstone_allowed["excluded"] == [
-        {"sid": tombstoned.sid, "reason": "status:tombstoned"}
-    ]
+    assert tombstone_allowed["excluded"] == [{"sid": tombstoned.sid, "reason": "status:tombstoned"}]
     assert pack["pack_id"]
     assert pack["text_sha256"]
 


### PR DESCRIPTION
## Summary
Adds a tamper-evident SQLite run ledger as the source of truth, a claim/evidence graph layered on spans, the v2 typed-span model, and a platform-aware assistant installer. (Branch also carries the earlier grouped multi-claim verifier work.)

## Changes

**SQLite ledger + claim/evidence graph** (`run_ledger.py`)
- `run.sqlite` is the source of truth: normalized tables for runs, spans, attempts, claims, claim/evidence links, audits, plus a chained `ledger_events` table with payload and event hashes. Load fails closed on corruption or manual edits.
- `run.json` and the TSV files remain as inspection/compat exports; legacy JSON-only runs migrate into the v3 schema on load.
- Claim tools: `create_claim`, `link_claim_evidence`, `list_claim_evidence`, `audit_claims`, `mark_claim`, `list_claims`, `get_claim`, `list_audits`. `supports`/`contradicts` edges must point at citable evidence.

**Span management v2** (`enforcement.py`, `mcp_server.py`, `docs/SPANS.md`)
- Typed, immutable, provenance-bearing spans (kind, locator, snapshot, trust, status, sensitivity, lineage).
- Server-resolved evidence packs and run-scoped verifier variants (`detect_hallucination_run`, `audit_trace_budget_run`); anchors and stale/sensitive/non-citable spans are excluded by policy.

**Assistant installer** (`installer.py`, `cli.py`, `docs/INSTALL.md`)
- `berry install` / per-platform commands with user and project scopes, hooks, and always-on instruction files.

## Tests
- `pytest tests/unit` -> 87 passed (incl. new `test_span_management_v2`, `test_claim_evidence_graph`, `test_installer`).
- Tamper-evidence verified: edits to the run payload, a span row, or the event chain all fail closed on load.

## Notes
- Persistence writes a full atomic snapshot per commit (SQLite + JSON/TSV exports), so per-commit write cost is higher than the old JSON-only store for long runs; loads stay fast.
- `sqlite3` is stdlib; no new dependencies.
