### PR TITLE
fix(verifier): accept span 'id' as a fallback for 'sid'

### DIFF
--- a/src/berry/hallucination_detector/core.py
+++ b/src/berry/hallucination_detector/core.py
@@ -81,7 +81,10 @@ def _normalize_spans(spans: Sequence[Any]) -> List[Span]:
     for raw in spans or []:
         if not isinstance(raw, dict):
             continue
-        sid = str(raw.get("sid", "")).strip()
+        # Accept "id" as a fallback for "sid"; callers routinely key spans by
+        # "id", which otherwise normalizes to an empty sid and gets dropped,
+        # leaving zero spans (status=no_spans, verifier never runs).
+        sid = str(raw.get("sid") or raw.get("id") or "").strip()
         text = str(raw.get("text", "")).strip()
         if not sid or not text:
             continue

--- a/src/berry/hallucination_detector/trace_budget.py
+++ b/src/berry/hallucination_detector/trace_budget.py
@@ -246,9 +246,12 @@ _AUX_Q_RE = re.compile(
 
 
 def _span_sid(span: Any) -> str:
+    # Accept "id" as a fallback for "sid": callers routinely build the spans
+    # array keyed by "id", which previously read as empty and silently dropped
+    # the span from known_ids/context selection (verifier never ran).
     if isinstance(span, dict):
-        return str(span.get("sid", ""))
-    return str(getattr(span, "sid", ""))
+        return str(span.get("sid") or span.get("id") or "")
+    return str(getattr(span, "sid", None) or getattr(span, "id", None) or "")
 
 
 def _field(obj: Any, name: str, default: Any = None) -> Any:

--- a/tests/unit/test_hallucination_core.py
+++ b/tests/unit/test_hallucination_core.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from berry.hallucination_detector.core import run_audit_trace_budget, run_detect_hallucination
+from berry.hallucination_detector.core import (
+    _normalize_spans,
+    run_audit_trace_budget,
+    run_detect_hallucination,
+)
 
 
 def test_detect_missing_citations_fails_without_backend(monkeypatch) -> None:
@@ -81,6 +85,18 @@ def test_audit_trace_budget_fails_closed_without_spans() -> None:
     assert out["details"][0]["status"] == "no_spans"
     assert out["details"][0]["no_spans"] is True
     assert out["summary"]["verifier_calls_planned"] == 0
+
+
+def test_normalize_spans_accepts_id_as_sid_fallback() -> None:
+    # Regression: id-keyed spans normalized to sid="" and were dropped here,
+    # leaving zero spans (status=no_spans) on the detect/audit entry points.
+    assert [(s.sid, s.text) for s in _normalize_spans([{"id": "S0", "text": "x"}])] == [("S0", "x")]
+    # sid still wins when both are present.
+    assert _normalize_spans([{"sid": "S0", "id": "OTHER", "text": "x"}])[0].sid == "S0"
+    # empty sid falls through to id.
+    assert _normalize_spans([{"sid": "", "id": "S0", "text": "x"}])[0].sid == "S0"
+    # neither key -> dropped as before.
+    assert _normalize_spans([{"text": "x"}]) == []
 
 
 def test_audit_trace_budget_uses_consistent_detail_schema(monkeypatch) -> None:

--- a/tests/unit/test_trace_budget.py
+++ b/tests/unit/test_trace_budget.py
@@ -538,6 +538,45 @@ def test_score_trace_budget_accepts_dict_like_trace(monkeypatch) -> None:
     assert backend.batches
 
 
+def test_spans_keyed_by_id_are_accepted_like_sid(monkeypatch) -> None:
+    # Regression: spans keyed by "id" (instead of "sid") used to read as empty,
+    # dropping them from known_ids/context so cited claims fell into
+    # unknown_citations and the verifier never ran. "id" is now a sid fallback.
+    backend = ScriptedBackend(
+        [
+            _text_result(yes=0.97, no=0.01, unsure=0.02, token="YES"),
+            _text_result(yes=0.05, no=0.10, unsure=0.85, token="UNSURE"),
+        ]
+    )
+    monkeypatch.setattr(tb, "make_backend", lambda _cfg: backend)
+
+    [res] = tb.score_trace_budget(
+        trace={
+            "steps": [
+                {"idx": 0, "claim": "The service supports Gemini.", "cites": ["S0"], "confidence": 0.95}
+            ],
+            "spans": [{"id": "S0", "text": "The service supports Gemini."}],
+        },
+        verifier_model="verifier",
+        backend_cfg=BackendConfig(kind="scripted"),
+        context_mode="cited",
+        use_cache=False,
+    )
+
+    assert res.status == "passed"
+    assert res.unknown_citations == []
+    assert res.skipped_verifier is False
+    assert res.verifier_calls > 0
+    assert 'id="S0"' in backend.batches[0][0]
+
+
+def test_span_sid_prefers_sid_over_id(monkeypatch) -> None:
+    assert tb._span_sid({"sid": "S0", "id": "OTHER"}) == "S0"
+    assert tb._span_sid({"id": "S0"}) == "S0"
+    assert tb._span_sid({"sid": "", "id": "S0"}) == "S0"
+    assert tb._span_sid({}) == ""
+
+
 def test_group_claims_false_preserves_single_claim_prompt_shape(monkeypatch) -> None:
     backend = ScriptedBackend(
         [


### PR DESCRIPTION
Accept span 'id' as a fallback for 'sid' so id-keyed spans are no longer dropped.